### PR TITLE
release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - Inline links in any node content (custom fields or in post_content) will be replaced with local relative links. https://your-beautiful-wp-site.com/page-2 will become /page-2 so that Gatsby can make sense of it.
 
+## 0.5.0
+
+### Breaking Changes
+
+- WPGraphQL and WPGatsby minimum versions have been bumped to 0.9.1 and 0.4.0 due to an oversight in how Menu Relay id's were constructed. Using WPGQL 0.9.0 and WPGatsby 0.4.0 would lead to inconsistent caching behaviour for menus.
+
+### New Features
+
+- Added a minimum version "reason" field to supported plugin versions to add an explanation for the minimum versions.
+
 ## 0.4.5
 
 ### New Features

--- a/src/steps/check-plugin-requirements.js
+++ b/src/steps/check-plugin-requirements.js
@@ -56,6 +56,27 @@ const areRemotePluginVersionsSatisfied = async ({ helpers }) => {
     }
   }
 
+  // a message explaining why these are the minimum versions
+  const reasons = `${
+    supportedWpPluginVersions.WPGraphQL.reason ||
+    supportedWpPluginVersions.WPGatsby.reason
+      ? `\n\nReasons:\n\n`
+      : ``
+  }${
+    supportedWpPluginVersions.WPGraphQL.reason
+      ? `- ${supportedWpPluginVersions.WPGraphQL.reason}`
+      : ``
+  }${
+    supportedWpPluginVersions.WPGraphQL.reason &&
+    supportedWpPluginVersions.WPGatsby.reason
+      ? `\n\n`
+      : ``
+  }${
+    supportedWpPluginVersions.WPGatsby.reason
+      ? `- ${supportedWpPluginVersions.WPGatsby.reason}`
+      : ``
+  }`
+
   let message
 
   if (!wpgqlIsSatisfied && wpGatsbyIsSatisfied) {
@@ -64,18 +85,21 @@ const areRemotePluginVersionsSatisfied = async ({ helpers }) => {
 \tDownload v ${supportedWpPluginVersions.WPGraphQL.version} at https://github.com/wp-graphql/wp-graphql/releases
 
 \tIf you're upgrading from an earlier version, read the release notes for each version between your old and new versions to determine which breaking changes you might encounter based on your use of the schema.
+${reasons}
 `
   }
 
   if (!wpGatsbyIsSatisfied) {
     message = `Your remote version of WPGatsby is not within the accepted range (${supportedWpPluginVersions.WPGatsby.version})
 
-\tDownload v ${supportedWpPluginVersions.WPGatsby.version} at https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental/tree/master/WordPress/plugins`
+\tDownload v ${supportedWpPluginVersions.WPGatsby.version} at https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental/tree/master/WordPress/plugins
+${reasons}`
   }
 
   if (!wpGatsbyIsSatisfied && !wpgqlIsSatisfied) {
     message = `WPGatsby and WPGraphQL are both outside the accepted version ranges.
-visit https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental/tree/master/WordPress/plugins to download the latest versions.`
+visit https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental/tree/master/WordPress/plugins to download the latest versions.
+${reasons}`
   }
 
   if (message) {

--- a/src/supported-remote-plugin-versions.js
+++ b/src/supported-remote-plugin-versions.js
@@ -2,10 +2,12 @@
 // it indicates which versions we will actually support AND which versions work.
 const supportedWpPluginVersions = {
   WPGraphQL: {
-    version: `~0.9.0`,
+    version: `~0.9.1`,
+    reason: `WPGraphQL 0.9.0 isn't supported because menu item relay id's changed from nav_menu:id to term:id in 0.9.1.\nUsing WPGatsby 0.4.0 and WPGraphQL 0.9.0 would lead to inconsistent cache invalidation for menus.\nThis doesn't mean you're on WPGraphQL 0.9.0, but explains why the minimum version is 0.9.1`,
   },
   WPGatsby: {
-    version: `~0.3.0`,
+    version: `~0.4.0`,
+    reason: `WPGatsby 0.4.0 supports WPGraphQL 0.9.1`,
   },
 }
 


### PR DESCRIPTION
Bump minimum remote plugin versions and add minimum version reason to error message. See Changelog for more info