### PR TITLE
exclude more enqueued types by default

### DIFF
--- a/.test-runtime/__tests__/integration/schema/__snapshots__/integrity.test.js.snap
+++ b/.test-runtime/__tests__/integration/schema/__snapshots__/integrity.test.js.snap
@@ -32,14 +32,6 @@ Array [
   },
   Object {
     "fields": null,
-    "name": "WpUserToEnqueuedScriptConnectionFilterInput",
-  },
-  Object {
-    "fields": null,
-    "name": "WpUserToEnqueuedStylesheetConnectionFilterInput",
-  },
-  Object {
-    "fields": null,
     "name": "WpUserToMediaItemConnectionFilterInput",
   },
   Object {
@@ -81,14 +73,6 @@ Array [
   Object {
     "fields": null,
     "name": "WpPostTypeLabelDetailsFilterInput",
-  },
-  Object {
-    "fields": null,
-    "name": "WpContentNodeToEnqueuedScriptConnectionFilterInput",
-  },
-  Object {
-    "fields": null,
-    "name": "WpContentNodeToEnqueuedStylesheetConnectionFilterInput",
   },
   Object {
     "fields": null,
@@ -169,14 +153,6 @@ Array [
   Object {
     "fields": null,
     "name": "WpCategoryToCategoryConnectionFilterInput",
-  },
-  Object {
-    "fields": null,
-    "name": "WpTermNodeToEnqueuedScriptConnectionFilterInput",
-  },
-  Object {
-    "fields": null,
-    "name": "WpTermNodeToEnqueuedStylesheetConnectionFilterInput",
   },
   Object {
     "fields": null,
@@ -340,8 +316,6 @@ Array [
       "date",
       "desiredSlug",
       "editLast",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "guid",
       "id",
       "link",
@@ -361,8 +335,6 @@ Array [
       "comments",
       "databaseId",
       "description",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "firstName",
       "id",
       "lastName",
@@ -498,8 +470,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "excerpt",
       "featuredImage",
       "guid",
@@ -569,8 +539,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "guid",
       "id",
       "language",
@@ -733,18 +701,6 @@ Array [
   },
   Object {
     "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpContentNodeToEnqueuedScriptConnection",
-  },
-  Object {
-    "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpContentNodeToEnqueuedStylesheetConnection",
-  },
-  Object {
-    "fields": Array [
       "id",
       "locale",
       "name",
@@ -846,8 +802,6 @@ Array [
       "count",
       "databaseId",
       "description",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "id",
       "language",
       "link",
@@ -874,8 +828,6 @@ Array [
       "count",
       "databaseId",
       "description",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "id",
       "link",
       "name",
@@ -886,18 +838,6 @@ Array [
       "nodeType",
     ],
     "name": "WpTermNode",
-  },
-  Object {
-    "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpTermNodeToEnqueuedScriptConnection",
-  },
-  Object {
-    "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpTermNodeToEnqueuedStylesheetConnection",
   },
   Object {
     "fields": Array [
@@ -940,8 +880,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "excerpt",
       "featuredImage",
       "guid",
@@ -1024,8 +962,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "featuredImage",
       "guid",
       "id",
@@ -1105,8 +1041,6 @@ Array [
       "count",
       "databaseId",
       "description",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "id",
       "language",
       "link",
@@ -1193,8 +1127,6 @@ Array [
       "date",
       "desiredSlug",
       "editLast",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "featuredImage",
       "guid",
       "id",
@@ -1291,8 +1223,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "featuredImage",
       "guid",
       "id",
@@ -1327,8 +1257,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "featuredImage",
       "guid",
       "id",
@@ -1363,8 +1291,6 @@ Array [
       "desiredSlug",
       "editLast",
       "enclosure",
-      "enqueuedScripts",
-      "enqueuedStylesheets",
       "featuredImage",
       "guid",
       "id",
@@ -1394,18 +1320,6 @@ Array [
       "node",
     ],
     "name": "WpTranslationFilterTestToContentTypeConnection",
-  },
-  Object {
-    "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpUserToEnqueuedScriptConnection",
-  },
-  Object {
-    "fields": Array [
-      "pageInfo",
-    ],
-    "name": "WpUserToEnqueuedStylesheetConnection",
   },
   Object {
     "fields": Array [
@@ -2413,21 +2327,10 @@ Array [
     ],
     "name": "WpEditLock",
   },
-  Object {
-    "fields": Array [
-      "args",
-      "extra",
-      "handle",
-      "id",
-      "src",
-      "version",
-    ],
-    "name": "WpEnqueuedAsset",
-  },
 ]
 `;
 
-exports[`[gatsby-source-wordpress-experimental] schema integrity hasn't altered the local Gatsby schema 2`] = `"43cb5ad909c64a77b5d7c6b6982a2953"`;
+exports[`[gatsby-source-wordpress-experimental] schema integrity hasn't altered the local Gatsby schema 2`] = `"1f62e486febd671d8fe8868d36c2d88e"`;
 
 exports[`[gatsby-source-wordpress-experimental] schema integrity hasn't altered the remote WPGraphQL schema 1`] = `
 Array [

--- a/.test-runtime/__tests__/integration/schema/__snapshots__/query-generation.test.js.snap
+++ b/.test-runtime/__tests__/integration/schema/__snapshots__/query-generation.test.js.snap
@@ -21,22 +21,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       count
       databaseId
       description
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       id
       language {
         id
@@ -134,22 +118,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     language {
       id
@@ -242,22 +210,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     language {
       id
@@ -796,22 +748,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       guid
       id
       language {
@@ -980,22 +916,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     guid
     id
     language {
@@ -1159,22 +1079,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     guid
     id
     language {
@@ -1647,22 +1551,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       featuredImage {
         id
         sourceUrl
@@ -1839,22 +1727,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -2026,22 +1898,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -2188,22 +2044,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       excerpt
       featuredImage {
         id
@@ -2346,22 +2186,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     excerpt
     featuredImage {
       id
@@ -2499,22 +2323,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     excerpt
     featuredImage {
       id
@@ -2639,22 +2447,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       featuredImage {
         id
         sourceUrl
@@ -2739,22 +2531,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -2834,22 +2610,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -2970,22 +2730,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       count
       databaseId
       description
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       id
       language {
         id
@@ -3066,22 +2810,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     language {
       id
@@ -3157,22 +2885,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     language {
       id
@@ -3409,22 +3121,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       excerpt
       featuredImage {
         id
@@ -3584,22 +3280,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     excerpt
     featuredImage {
       id
@@ -3754,22 +3434,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     excerpt
     featuredImage {
       id
@@ -3864,22 +3528,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       count
       databaseId
       description
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       id
       link
       name
@@ -3904,22 +3552,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     link
     name
@@ -3939,22 +3571,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     count
     databaseId
     description
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     id
     link
     name
@@ -3989,22 +3605,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       featuredImage {
         id
         sourceUrl
@@ -4097,22 +3697,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4200,22 +3784,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4304,22 +3872,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       featuredImage {
         id
         sourceUrl
@@ -4392,22 +3944,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4475,22 +4011,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4559,22 +4079,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
         id
       }
       enclosure
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       featuredImage {
         id
         sourceUrl
@@ -4647,22 +4151,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4730,22 +4218,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       id
     }
     enclosure
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     featuredImage {
       id
       sourceUrl
@@ -4829,22 +4301,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
       databaseId
       description
       email
-      enqueuedScripts {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
-      enqueuedStylesheets {
-        pageInfo {
-          endCursor
-          hasNextPage
-          hasPreviousPage
-          startCursor
-        }
-      }
       extraCapabilities
       firstName
       id
@@ -4990,22 +4446,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     databaseId
     description
     email
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     extraCapabilities
     firstName
     id
@@ -5146,22 +4586,6 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
     databaseId
     description
     email
-    enqueuedScripts {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
-    enqueuedStylesheets {
-      pageInfo {
-        endCursor
-        hasNextPage
-        hasPreviousPage
-        startCursor
-      }
-    }
     extraCapabilities
     firstName
     id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
+## 0.7.4
+
+### Bug Fixes
+
+- Automatically excluded EnqueuedAsset, ContentNodeToEnqueuedScriptConnection, ContentNodeToEnqueuedStylesheetConnection, TermNodeToEnqueuedScriptConnection, TermNodeToEnqueuedStylesheetConnection, UserToEnqueuedScriptConnection, UserToEnqueuedStylesheetConnection types because these types can't be properly utilized yet without causing errors.
+
 ## 0.7.3
+
+### Bug Fixes
 
 - Sometimes at the bottom of our query depth limit, fields which require a selection set were being queried without.
 - Fixed an error for non-image media items where the build would fail since 0.7.1. The problem was that we were trying to access the media item by `sourceUrl` but non-image media items only have a `mediaItemUrl`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"

--- a/src/models/gatsby-api.js
+++ b/src/models/gatsby-api.js
@@ -188,10 +188,33 @@ const defaultPluginOptions = {
       // },
     },
     // the next two types can't be sourced in Gatsby properly yet
+    // @todo instead of excluding these manually, auto exclude them
+    // based on how they behave (no single node query available)
     EnqueuedScript: {
       exclude: true,
     },
     EnqueuedStylesheet: {
+      exclude: true,
+    },
+    EnqueuedAsset: {
+      exclude: true,
+    },
+    ContentNodeToEnqueuedScriptConnection: {
+      exclude: true,
+    },
+    ContentNodeToEnqueuedStylesheetConnection: {
+      exclude: true,
+    },
+    TermNodeToEnqueuedScriptConnection: {
+      exclude: true,
+    },
+    TermNodeToEnqueuedStylesheetConnection: {
+      exclude: true,
+    },
+    UserToEnqueuedScriptConnection: {
+      exclude: true,
+    },
+    UserToEnqueuedStylesheetConnection: {
       exclude: true,
     },
   },


### PR DESCRIPTION
published in `gatsby-source-wordpress-experimental@0.7.4`

Fixes #6 