### PR TITLE
Fix: Use path prefix from helpers

### DIFF
--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -363,7 +363,7 @@ const replaceNodeHtmlImages = async ({
 
         const quality = pluginOptions?.html?.imageQuality
 
-        const { reporter, cache } = helpers
+        const { reporter, cache, pathPrefix } = helpers
 
         let fluidResult
 
@@ -373,7 +373,7 @@ const replaceNodeHtmlImages = async ({
             args: {
               maxWidth,
               quality,
-              pathPrefix: pluginOptions.pathPrefix,
+              pathPrefix,
             },
             reporter,
             cache,


### PR DESCRIPTION
This branch updates the call to `fluid` by passing the `pathPrefix` option configured at the top level of a Gatsby configuration, rather than one from the plugin's own `pluginOptions`. This change means that if `gatsby build` is called without `--prefix-paths`, the `helpers.pathPrefix` will be an empty string, which is the correct behaviour.