### PR TITLE
Add refetcher delayed retry with logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.4
+
+### Bug Fixes
+
+- Previously when in `gatsby develop` or in a Preview instance, if the connection to WP went down for a moment it would fail the build. It now displays an activity timer with the number of times it's retried, and then a success message when it finally does succeed.
+
 ## 1.2.3
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"
   },

--- a/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -22,6 +22,7 @@ const paginatedWpNodeFetch = async ({
   nodeTypeName,
   helpers,
   throwFetchErrors = false,
+  throwGqlErrors = false,
   allContentNodes = [],
   after = null,
   settings = {},
@@ -56,6 +57,7 @@ const paginatedWpNodeFetch = async ({
   const response = await fetchGraphql({
     query,
     throwFetchErrors,
+    throwGqlErrors,
     variables: {
       ...variables,
       after,

--- a/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -2,12 +2,52 @@ import fetchAndApplyNodeUpdates from "./fetch-node-updates"
 import { formatLogMessage } from "~/utils/format-log-message"
 import store from "~/store"
 
-const refetcher = async (msRefetchInterval) => {
-  await fetchAndApplyNodeUpdates({
-    intervalRefetching: true,
-  })
+const refetcher = async (
+  msRefetchInterval,
+  helpers,
+  { reconnectionActivity = null, retryCount = 0 } = {}
+) => {
+  try {
+    await fetchAndApplyNodeUpdates({
+      intervalRefetching: true,
+      throwFetchErrors: true,
+      throwGqlErrors: true,
+    })
 
-  setTimeout(() => refetcher(msRefetchInterval), msRefetchInterval)
+    if (reconnectionActivity) {
+      reconnectionActivity.end()
+      helpers.reporter.success(
+        formatLogMessage(
+          `Content updates re-connected after ${retryCount} tries`
+        )
+      )
+
+      reconnectionActivity = null
+      retryCount = 0
+    }
+  } catch (e) {
+    if (!reconnectionActivity) {
+      reconnectionActivity = helpers.reporter.activityTimer(
+        formatLogMessage(`Content update error: "${e.message}"`)
+      )
+      reconnectionActivity.start()
+      reconnectionActivity.setStatus(`retrying...`)
+    } else {
+      retryCount++
+      reconnectionActivity.setStatus(`retried ${retryCount} times`)
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 30000))
+  }
+
+  setTimeout(
+    () =>
+      refetcher(msRefetchInterval, helpers, {
+        reconnectionActivity,
+        retryCount,
+      }),
+    msRefetchInterval
+  )
 }
 
 /**
@@ -33,7 +73,7 @@ const startPollingForContentUpdates = (helpers, pluginOptions) => {
     helpers.reporter.info(formatLogMessage`Watching for WordPress changes`)
   }
 
-  refetcher(msRefetchInterval)
+  refetcher(msRefetchInterval, helpers)
 }
 
 export { startPollingForContentUpdates }

--- a/src/steps/source-nodes/update-nodes/fetch-node-updates.js
+++ b/src/steps/source-nodes/update-nodes/fetch-node-updates.js
@@ -18,7 +18,12 @@ export const touchValidNodes = async () => {
  * onPreBootstrap to ask WordPress for the latest changes, and then
  * apply creates, updates, and deletes to Gatsby nodes
  */
-const fetchAndApplyNodeUpdates = async ({ since, intervalRefetching }) => {
+const fetchAndApplyNodeUpdates = async ({
+  since,
+  intervalRefetching,
+  throwFetchErrors = false,
+  throwGqlErrors = false,
+}) => {
   const { helpers, pluginOptions } = getGatsbyApi()
 
   const { cache, reporter } = helpers
@@ -42,6 +47,8 @@ const fetchAndApplyNodeUpdates = async ({ since, intervalRefetching }) => {
     intervalRefetching,
     helpers,
     pluginOptions,
+    throwFetchErrors,
+    throwGqlErrors,
   })
 
   if (

--- a/src/steps/source-nodes/update-nodes/wp-actions/index.js
+++ b/src/steps/source-nodes/update-nodes/wp-actions/index.js
@@ -16,7 +16,12 @@ const previouslyFetchedActionIds = []
  * An example of a non-valid change would be a post that was created
  * and then immediately deleted.
  */
-export const getWpActions = async ({ variables, helpers }) => {
+export const getWpActions = async ({
+  variables,
+  helpers,
+  throwFetchErrors = false,
+  throwGqlErrors = false,
+}) => {
   // current time minus 5 seconds so we don't lose updates between the cracks
   // if someone bulk-edits a list of nodes in WP
   // @todo make this cursor based so we don't need to do this.
@@ -30,6 +35,8 @@ export const getWpActions = async ({ variables, helpers }) => {
     query: actionMonitorQuery,
     nodeTypeName: `ActionMonitor`,
     helpers,
+    throwFetchErrors,
+    throwGqlErrors,
     ...variables,
   })
 
@@ -113,6 +120,8 @@ export const fetchAndRunWpActions = async ({
   pluginOptions,
   intervalRefetching,
   since,
+  throwFetchErrors = false,
+  throwGqlErrors = false,
 }) => {
   // check for new, edited, or deleted posts in WP "Action Monitor"
   const wpActions = await getWpActions({
@@ -120,6 +129,8 @@ export const fetchAndRunWpActions = async ({
       since,
     },
     helpers,
+    throwFetchErrors,
+    throwGqlErrors,
   })
 
   const didUpdate = !!wpActions.length


### PR DESCRIPTION
Previously, if WP went down for a moment, it would cause the develop delta checker to fail the process. Now it will wait until WP comes back up and then resume:
<img width="1259" alt="Screen Shot 2020-08-04 at 2 13 46 PM" src="https://user-images.githubusercontent.com/14190743/89351807-9bacf380-d667-11ea-8dfb-6f0af20ab096.png">

Published in `gatsby-source-wordpress-experimental@1.2.4`