### PR TITLE
CLI: use chalk inverse() to safely support multiple terminal themes

### DIFF
--- a/src/utils/format-log-message.js
+++ b/src/utils/format-log-message.js
@@ -16,7 +16,7 @@ const formatLogMessage = (input, { useVerboseStyle } = {}) => {
   }
 
   return verbose || useVerboseStyle
-    ? `${chalk.white.bgBlue(` gatsby-source-wordpress `)} ${message}`
+    ? `${chalk.inverse(` gatsby-source-wordpress `)} ${message}`
     : `[gatsby-source-wordpress] ${message}`
 }
 

--- a/src/utils/format-log-message.js
+++ b/src/utils/format-log-message.js
@@ -16,7 +16,7 @@ const formatLogMessage = (input, { useVerboseStyle } = {}) => {
   }
 
   return verbose || useVerboseStyle
-    ? `${chalk.inverse(` gatsby-source-wordpress `)} ${message}`
+    ? `${chalk.bgBlue.white(` gatsby-source-wordpress `)} ${message}`
     : `[gatsby-source-wordpress] ${message}`
 }
 


### PR DESCRIPTION
Running white text on blue background doesn't work on light terminal themes.

To be safe, we should use chalk's default `inverse` modifier.

Tested on dark and light themes.

Reference: https://github.com/chalk/chalk#modifiers

Addresses #57

**Current**

![image](https://user-images.githubusercontent.com/1371573/88345299-88f6fe00-ccfa-11ea-9f1d-c51958dd0441.png)


**Proposed solution (`inverse`)**

![image](https://user-images.githubusercontent.com/1371573/89743423-f1164580-da57-11ea-8f25-fc952ffbba9c.png)
![image](https://user-images.githubusercontent.com/1371573/89743429-fa071700-da57-11ea-93b2-25a1ba16b1ec.png)
