### PR TITLE
Fix code example

### DIFF
--- a/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md
+++ b/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md
@@ -101,7 +101,7 @@ This first query will pull in the blogpost content from WordPress:
 
 ```graphql
 query {
-    allWpPage {
+    allWpPost {
         nodes {
             id
             title


### PR DESCRIPTION
WordPress pages do not have any excerpt only posts have it.