### PR TITLE
fix nodeMetaByUrl caching issue

### DIFF
--- a/src/models/image-nodes.js
+++ b/src/models/image-nodes.js
@@ -24,9 +24,14 @@ const imageNodes = {
 
     pushNodeMeta(state, { id, sourceUrl, modifiedGmt }) {
       state.nodeIds.push(id)
-      state.nodeMetaByUrl[stripImageSizesFromUrl(sourceUrl)] = {
-        id,
-        modifiedGmt,
+      const nodeUrl = stripImageSizesFromUrl(sourceUrl);
+      // dont overwrite the lookup table in case we have multiple
+      // sized urls for the same image
+      if (!state.nodeMetaByUrl[nodeUrl]) {
+        state.nodeMetaByUrl[nodeUrl] = {
+          id,
+          modifiedGmt,
+        };
       }
 
       return state

--- a/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -72,9 +72,20 @@ export const getFileNodeByMediaItemNode = async ({
     // and it hasn't been modified
     existingNodeMeta.modifiedGmt === modifiedGmt
   ) {
-    const node = await helpers.getNode(existingNodeMeta.id)
+    let node = await helpers.getNode(existingNodeMeta.id)
 
-    return node
+    // some of the cached node metas dont necessarily need to be a File
+    // so check that we really read a file node
+    if (node.internal.type !== 'File') {
+      if (node.localFile && node.localFile.id) {
+        // look up the corresponding file node
+        node = await helpers.getNode(node.localFile.id)
+      } else {
+        return null;
+      }
+    }
+
+    return node;
   }
 
   return null


### PR DESCRIPTION
- in the case where the same image gets referenced both in an ACF (without size spec) and within HTML
  then getFileNodeByMediaItemNode
  will return a medianode rather than
  the expected file node
- this patch avoids overwriting the
  `nodeMetaByUrl` cache
  as well as ensuring that
  `getFileNodeByMediaItemNode` will
  always return a fileNode

- note that I am not certain that both changes are strictly needed 

- fixes #153 