### PR TITLE
fix undefined dereference in case the cached node no longer exists

### DIFF
--- a/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -76,7 +76,7 @@ export const getFileNodeByMediaItemNode = async ({
 
     // some of the cached node metas dont necessarily need to be a File
     // so make sure we return a File node if what we get isn't one
-    if (node.internal.type !== `File`) {
+    if (node && node.internal && node.internal.type !== `File`) {
       if (node.localFile && node.localFile.id) {
         // look up the corresponding file node
         node = await helpers.getNode(node.localFile.id)


### PR DESCRIPTION
- in the case where the cached node is no longer in the node tree
  (possibly due to a refresh)
  then we were trying to dereference `node.internal` when
  `node` was `undefined`