### PR TITLE
Fix/relative images

### DIFF
--- a/.test-runtime/__tests__/integration/schema/__snapshots__/data-resolution.test.js.snap
+++ b/.test-runtime/__tests__/integration/schema/__snapshots__/data-resolution.test.js.snap
@@ -139,6 +139,10 @@ Array [
     "sourceUrl": "https://gatsbyinttests.wpengine.com/wp-content/uploads/2020/09/imagename-300x163-1-scaled.jpg",
   },
   Object {
+    "id": "cG9zdDo5ODI3",
+    "sourceUrl": "https://gatsbyinttests.wpengine.com/wp-content/uploads/2020/09/5642fae96ade14100be5-scaled.jpg",
+  },
+  Object {
     "id": "cG9zdDo5OQ==",
     "sourceUrl": "https://gatsbyinttests.wpengine.com/wp-content/uploads/2020/03/avatar.jpg",
   },
@@ -676,6 +680,22 @@ Object {
             "nodes": Array [],
           },
         },
+        Object {
+          "acfPageFields": Object {
+            "fieldGroupName": "acfPageFields",
+          },
+          "author": Object {
+            "node": Object {
+              "name": "Tyler",
+            },
+          },
+          "title": "Relative image path",
+          "translations": Array [],
+          "uri": "/relative-image-path/",
+          "wpChildren": Object {
+            "nodes": Array [],
+          },
+        },
       ],
     },
     "testPage": Object {
@@ -979,6 +999,22 @@ Object {
             },
           ],
           "uri": "/fr/image-test-1-french/",
+          "wpChildren": Object {
+            "nodes": Array [],
+          },
+        },
+        Object {
+          "acfPageFields": Object {
+            "fieldGroupName": "acfPageFields",
+          },
+          "author": Object {
+            "node": Object {
+              "name": "Tyler",
+            },
+          },
+          "title": "Relative image path",
+          "translations": Array [],
+          "uri": "/relative-image-path/",
           "wpChildren": Object {
             "nodes": Array [],
           },
@@ -1388,6 +1424,9 @@ Object {
           "pages": Object {
             "nodes": Array [
               Object {
+                "title": "Relative image path",
+              },
+              Object {
                 "title": "Image test 1 french",
               },
               Object {
@@ -1495,6 +1534,9 @@ Object {
           "name": "Tyler",
           "pages": Object {
             "nodes": Array [
+              Object {
+                "title": "Relative image path",
+              },
               Object {
                 "title": "Image test 1 french",
               },

--- a/.test-runtime/__tests__/integration/schema/data-resolution.test.js
+++ b/.test-runtime/__tests__/integration/schema/data-resolution.test.js
@@ -16,11 +16,11 @@ describe(`[gatsby-source-wordpress-experimental] data resolution`, () => {
 
     expect(data[`allWpMediaItem`].nodes).toBeTruthy()
     expect(data[`allWpMediaItem`].nodes).toMatchSnapshot()
-    expect(data[`allWpMediaItem`].totalCount).toBe(41)
+    expect(data[`allWpMediaItem`].totalCount).toBe(42)
 
     expect(data[`allWpTag`].totalCount).toBe(5)
     expect(data[`allWpUser`].totalCount).toBe(1)
-    expect(data[`allWpPage`].totalCount).toBe(17)
+    expect(data[`allWpPage`].totalCount).toBe(18)
     expect(data[`allWpPost`].totalCount).toBe(10)
     expect(data[`allWpComment`].totalCount).toBe(1)
     expect(data[`allWpProject`].totalCount).toBe(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+
+- In situations where MediaItem.sourceUrl is returned as an absolute path without the WP url, File nodes were unable to be fetched from MediaItem nodes because the URL was wrong.
+- Images with `-scaled` as part of the sourceUrl were cached properly but were not being restored from the cache properly.
+- There was duplicative cache logic running for media item node id's which was unneccessary.
+
 ## 1.4.4
 
 - Improved the compatibility API error message to make it clearer that you may need to upgrade OR downgrade WPGraphQL, WPGatsby, or gatsby-source-wordpress-experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 - In situations where MediaItem.sourceUrl is returned as an absolute path without the WP url, File nodes were unable to be fetched from MediaItem nodes because the URL was wrong.
-- Images with `-scaled` as part of the sourceUrl were cached properly but were not being restored from the cache properly.
+- Images with `-scaled` as part of the sourceUrl were cached properly but were not being restored from the cache properly when html url's included the full size url instead of the `-scaled` url.
 - There was duplicative cache logic running for media item node id's which was unneccessary.
 
 ## 1.4.4

--- a/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -9,10 +9,11 @@ import { createFileNodeFromBuffer } from "gatsby-source-filesystem"
 import createRemoteFileNode from "./create-remote-file-node/index"
 
 import store from "~/store"
-import { getGatsbyApi } from "~/utils/get-gatsby-api"
+
 import urlToPath from "~/utils/url-to-path"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { stripImageSizesFromUrl } from "~/steps/source-nodes/fetch-nodes/fetch-referenced-media-items"
+import { ensureSrcHasHostname } from "./process-node"
 
 export const getFileNodeMetaBySourceUrl = (sourceUrl) => {
   const fileNodesMetaByUrls = store.getState().imageNodes.nodeMetaByUrl
@@ -115,11 +116,14 @@ export const createRemoteMediaItemNode = async ({
     actions: { createNode },
   } = helpers
 
-  const { mediaItemUrl, modifiedGmt, mimeType, title } = mediaItemNode
+  let { mediaItemUrl, modifiedGmt, mimeType, title } = mediaItemNode
 
   if (!mediaItemUrl) {
     return null
   }
+
+  const { wpUrl } = state.remoteSchema
+  mediaItemUrl = ensureSrcHasHostname({ wpUrl, src: mediaItemUrl })
 
   const { excludeByMimeTypes } = pluginOptions.type?.MediaItem?.localFile
 
@@ -173,7 +177,6 @@ export const createRemoteMediaItemNode = async ({
         }
       }
 
-      const { wpUrl } = state.remoteSchema
       const { hostname: wpUrlHostname } = url.parse(wpUrl)
       const { hostname: mediaItemHostname } = url.parse(mediaItemUrl)
 

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -110,6 +110,14 @@ const pickNodeBySourceUrlOrCheerioImg = ({
     (mediaItemNode) =>
       // either find our node by the source url
       possibleHtmlSrcs.includes(mediaItemNode.sourceUrl) ||
+      possibleHtmlSrcs.includes(
+        // try to match without -scaled in the sourceUrl as well
+        // since WP adds -scaled to image urls if they were too large
+        // at upload time but image urls in html don't have this requirement.
+        // the sourceUrl may have -scaled in it but the full size image is still
+        // stored on the server (just not in the db)
+        mediaItemNode.sourceUrl.replace(`-scaled`, ``)
+      ) ||
       // or by id for cases where the src url didn't return a node
       (!!cheerioImg && getCheerioImgRelayId(cheerioImg) === mediaItemNode.id)
   )

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -242,9 +242,6 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
           ...helpers,
           createNode: helpers.actions.createNode,
         })
-
-        // save this file node id to cache the node properly
-        createdNodeIds.push(imageNode.id)
       } catch (e) {
         if (typeof e === `string` && e.includes(`404`)) {
           const nodeEditLink = getNodeEditLink(node)
@@ -279,20 +276,6 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
 
       // match is the html string of the img tag
       htmlMatchesToMediaItemNodesMap.set(match, { imageNode, cheerioImg })
-    }
-  }
-
-  // if we've created nodes we need to save the id's so they get touched
-  // on the next build and aren't garbage collected
-  // @todo this should be written 1 time, not on each node transformation
-  if (createdNodeIds.length) {
-    const previouslyCreatedNodeIds =
-      (await helpers.cache.get(CREATED_NODE_IDS)) || []
-
-    const allCreatedNodeIds = [...createdNodeIds, ...previouslyCreatedNodeIds]
-
-    if (allCreatedNodeIds.length) {
-      await helpers.cache.set(CREATED_NODE_IDS, allCreatedNodeIds)
     }
   }
 

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -135,12 +135,15 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
 }) => {
   // get all the image nodes we've cached from elsewhere
   const { nodeMetaByUrl } = store.getState().imageNodes
+
   const previouslyCachedNodesByUrl = (
     await Promise.all(
       Object.entries(nodeMetaByUrl).map(([sourceUrl, { id } = {}]) => {
         if (!sourceUrl || !id) {
           return null
         }
+
+        sourceUrl = ensureSrcHasHostname({ wpUrl, src: sourceUrl })
 
         return {
           sourceUrl,
@@ -153,8 +156,10 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
   const mediaItemUrls = cheerioImages
     // filter out nodes we already have
     .filter(({ cheerioImg }) => {
+      const url = ensureSrcHasHostname({ wpUrl, src: cheerioImg.attribs.src })
+
       const existingNode = pickNodeBySourceUrlOrCheerioImg({
-        url: cheerioImg.attribs.src,
+        url,
         mediaItemNodes: previouslyCachedNodesByUrl,
       })
 


### PR DESCRIPTION
### Bug Fixes

- In situations where MediaItem.sourceUrl is returned as an absolute path without the WP url, File nodes were unable to be fetched from MediaItem nodes because the URL was wrong.
- Images with `-scaled` as part of the sourceUrl were cached properly but were not being restored from the cache properly when html url's included the full size url instead of the `-scaled` url.
- There was duplicative cache logic running for media item node id's which was unneccessary.

Fixes #181