### PR TITLE
fix preview for /?graphql

### DIFF
--- a/.test-runtime/.env.test
+++ b/.test-runtime/.env.test
@@ -1,2 +1,2 @@
-WPGRAPHQL_URL="https://gatsbyinttests.wpengine.com/graphql"
+WPGRAPHQL_URL="https://gatsbyinttests.wpengine.com/?graphql"
 # WPGRAPHQL_URL="http://automatedtestinggatsbysourcewordpresswpgraphql.local/graphql"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+
+- Fixed a bug where a Preview safeguard was preventing the usage of Preview with bedrock/roots (or any other setup that requires the gql endpoint to be used as /?graphql).
+
 ## 1.4.5
 
 ### Bug Fixes

--- a/src/steps/source-nodes/update-nodes/source-previews.js
+++ b/src/steps/source-nodes/update-nodes/source-previews.js
@@ -1,6 +1,7 @@
 import { fetchAndCreateSingleNode } from "~/steps/source-nodes/update-nodes/wp-actions/update"
 import { formatLogMessage } from "~/utils/format-log-message"
 import chalk from "chalk"
+import urlUtil from "url"
 
 export const sourcePreviews = async ({ webhookBody, reporter }, { url }) => {
   if (
@@ -13,7 +14,10 @@ export const sourcePreviews = async ({ webhookBody, reporter }, { url }) => {
     return
   }
 
-  if (url.split(`//`)[1] !== webhookBody.remoteUrl.split(`//`)[1]) {
+  const { hostname: settingsHostname } = urlUtil.parse(url)
+  const { hostname: remoteHostname } = urlUtil.parse(webhookBody.remoteUrl)
+
+  if (settingsHostname !== remoteHostname) {
     reporter.panic(
       formatLogMessage(
         `Received preview data from a different remote URL than the one specified in plugin options. \n\n ${chalk.bold(


### PR DESCRIPTION
Fixed a bug where a Preview safeguard was preventing the usage of Preview with bedrock/roots (or any other setup that requires the gql endpoint to be used as /?graphql).

Closes #185 