### PR TITLE
Fix/failed fetching images to build

### DIFF
--- a/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -249,7 +249,8 @@ async function processRemoteNode({
   // extensible. We should define a proper API that we validate.
   const httpOpts = {}
   if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
-    httpOpts.auth = `${auth.htaccess_user}:${auth.htaccess_pass}`
+    httpOpts.username = `${auth.htaccess_user}`
+    httpOpts.password = `${auth.htaccess_pass}`
   }
 
   // Create the temp and permanent file names for the url.

--- a/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -249,8 +249,8 @@ async function processRemoteNode({
   // extensible. We should define a proper API that we validate.
   const httpOpts = {}
   if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
-    httpOpts.username = `${auth.htaccess_user}`
-    httpOpts.password = `${auth.htaccess_pass}`
+    httpOpts.username = auth.htaccess_user
+    httpOpts.password = auth.htaccess_pass
   }
 
   // Create the temp and permanent file names for the url.


### PR DESCRIPTION
#53 #197
In version 1.5.3, an error occurred at the part where the first image was fetched and I could not proceed.
This seems to be limited to sites that use basic authentication, and according to the document, the auth option is deprecated for fetching by got.
https://github.com/sindresorhus/got#options
```
Note: Legacy URL support is disabled. options.path is supported only for backwards compatibility. Use options.pathname and options.searchParams instead. options.auth has been replaced with options.username &  #options.password.
```
Changed to accommodate it :)