### PR TITLE
Fix: beforeChangeNode and duplicate img tags

### DIFF
--- a/.test-runtime/__tests__/integration/schema/__snapshots__/gatsby-image.test.js.snap
+++ b/.test-runtime/__tests__/integration/schema/__snapshots__/gatsby-image.test.js.snap
@@ -23,6 +23,30 @@ exports[`[gatsby-source-wordpress-experimental] Gatsby image processing transfor
 /static/d48dfc77ee2f40d5eb835c6d6e3b594f/6afe2/aperture-vintage-346923-unsplash-scaled.jpg 1536w,
 /static/d48dfc77ee2f40d5eb835c6d6e3b594f/7a411/aperture-vintage-346923-unsplash-scaled.jpg 2048w,
 /static/d48dfc77ee2f40d5eb835c6d6e3b594f/bb9a8/aperture-vintage-346923-unsplash-scaled.jpg 2560w\\" src=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg\\" alt=\\"\\" style=\\"position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center\\"/></picture></noscript></div></figure>
+
+
+
+<figure class=\\"wp-block-image size-large\\"><div class=\\"wp-image-95 gatsby-image-wrapper\\" style=\\"position:relative;overflow:hidden;max-width:100%;width:1024px\\" data-reactroot=\\"\\"><div aria-hidden=\\"true\\" style=\\"width:100%;padding-bottom:66.796875%\\"></div><img aria-hidden=\\"true\\" src=\\"data:image/jpeg;base64,/9j/2wBDABALDA4MChAODQ4SERATGCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2P/2wBDARESEhgVGC8aGi9jQjhCY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2P/wgARCAANABQDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAQD/8QAFQEBAQAAAAAAAAAAAAAAAAAAAQL/2gAMAwEAAhADEAAAAYNcbGYAn//EABoQAAIDAQEAAAAAAAAAAAAAAAECAAMRECH/2gAIAQEAAQUCAjLnK/WuGCf/xAAXEQADAQAAAAAAAAAAAAAAAAAAARET/9oACAEDAQE/Ac6qQ//EABcRAAMBAAAAAAAAAAAAAAAAAAEQERP/2gAIAQIBAT8B0hi//8QAFBABAAAAAAAAAAAAAAAAAAAAIP/aAAgBAQAGPwJf/8QAGBAAAwEBAAAAAAAAAAAAAAAAAAERIWH/2gAIAQEAAT8hU2KjqGtMCJ20h//aAAwDAQACAAMAAAAQdA//xAAXEQADAQAAAAAAAAAAAAAAAAAAAREh/9oACAEDAQE/EN1ic//EABcRAAMBAAAAAAAAAAAAAAAAAAABEUH/2gAIAQIBAT8QhGyn/8QAGRAAAwEBAQAAAAAAAAAAAAAAAAERMSFB/9oACAEBAAE/EFJC+ldOYKwXXlZwro16Onp//9k=\\" alt=\\"\\" style=\\"position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:0;transition-delay:500ms\\"/><picture><source srcSet=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/b95e4/aperture-vintage-346923-unsplash-scaled.jpg 256w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/1779b/aperture-vintage-346923-unsplash-scaled.jpg 512w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg 1024w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/6afe2/aperture-vintage-346923-unsplash-scaled.jpg 1536w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/7a411/aperture-vintage-346923-unsplash-scaled.jpg 2048w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/bb9a8/aperture-vintage-346923-unsplash-scaled.jpg 2560w\\" sizes=\\"(max-width: 1024px) 100vw, 1024px\\"/><img sizes=\\"(max-width: 1024px) 100vw, 1024px\\" srcSet=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/b95e4/aperture-vintage-346923-unsplash-scaled.jpg 256w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/1779b/aperture-vintage-346923-unsplash-scaled.jpg 512w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg 1024w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/6afe2/aperture-vintage-346923-unsplash-scaled.jpg 1536w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/7a411/aperture-vintage-346923-unsplash-scaled.jpg 2048w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/bb9a8/aperture-vintage-346923-unsplash-scaled.jpg 2560w\\" src=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg\\" alt=\\"\\" loading=\\"eager\\" style=\\"position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;object-position:center;opacity:1;transition:opacity 500ms\\"/></picture><noscript><picture><source srcset=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/b95e4/aperture-vintage-346923-unsplash-scaled.jpg 256w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/1779b/aperture-vintage-346923-unsplash-scaled.jpg 512w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg 1024w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/6afe2/aperture-vintage-346923-unsplash-scaled.jpg 1536w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/7a411/aperture-vintage-346923-unsplash-scaled.jpg 2048w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/bb9a8/aperture-vintage-346923-unsplash-scaled.jpg 2560w\\" sizes=\\"(max-width: 1024px) 100vw, 1024px\\" /><img loading=\\"eager\\" sizes=\\"(max-width: 1024px) 100vw, 1024px\\" srcset=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/b95e4/aperture-vintage-346923-unsplash-scaled.jpg 256w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/1779b/aperture-vintage-346923-unsplash-scaled.jpg 512w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg 1024w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/6afe2/aperture-vintage-346923-unsplash-scaled.jpg 1536w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/7a411/aperture-vintage-346923-unsplash-scaled.jpg 2048w,
+/static/d48dfc77ee2f40d5eb835c6d6e3b594f/bb9a8/aperture-vintage-346923-unsplash-scaled.jpg 2560w\\" src=\\"/static/d48dfc77ee2f40d5eb835c6d6e3b594f/87945/aperture-vintage-346923-unsplash-scaled.jpg\\" alt=\\"\\" style=\\"position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center\\"/></picture></noscript></div></figure>
 "
 `;
 

--- a/.test-runtime/__tests__/integration/schema/gatsby-image.test.js
+++ b/.test-runtime/__tests__/integration/schema/gatsby-image.test.js
@@ -50,7 +50,7 @@ describe(`[gatsby-source-wordpress-experimental] Gatsby image processing`, () =>
     })
 
     expect(wpPage.content).toBeTruthy()
-    expect(wpPage.content).toMatch(/gatsby-image-wrapper/)
+    expect(countGatsbyImgs(wpPage.content)).toBe(2)
     expect(wpPage.content).toMatchSnapshot()
 
     expect(gute.content).toBeTruthy()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.5.4
+
+### Bug Fixes
+
+- the `options.type[typename]type.beforeChangeNode` api was not running when creating all nodes, just when updating nodes. This now runs before all node updates (create, update, delete).
+- When replacing images with Gatsby images in html fields, only the first instance of an image was being replaced if there were more than 1 identical HTML <img /> strings.
+
 ## 1.5.3
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"
   },

--- a/src/steps/source-nodes/create-nodes/create-nodes.js
+++ b/src/steps/source-nodes/create-nodes/create-nodes.js
@@ -48,7 +48,7 @@ export const createNodeWithSideEffects = ({
     })
   }
 
-  const remoteNode = {
+  let remoteNode = {
     ...node,
     id: node.id,
     parent: null,
@@ -63,7 +63,7 @@ export const createNodeWithSideEffects = ({
   })
 
   if (typeof typeSettings?.beforeChangeNode === `function`) {
-    const { additionalNodeIds } =
+    const { additionalNodeIds, remoteNode: changedRemoteNode } =
       (await typeSettings.beforeChangeNode({
         actionType: `CREATE_ALL`,
         remoteNode,
@@ -75,6 +75,10 @@ export const createNodeWithSideEffects = ({
         buildTypeName,
         wpStore: store,
       })) || {}
+
+    if (changedRemoteNode) {
+      remoteNode = changedRemoteNode
+    }
 
     if (additionalNodeIds?.length && totalSideEffectNodes) {
       additionalNodeIds.forEach(

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -403,7 +403,9 @@ const replaceNodeHtmlImages = async ({
       // or it's an absolute path
       subMatches[0].includes('src=\\"/wp-content')
 
-    const isInJSON = subMatches[0].includes(`\\/\\/`)
+    // six backslashes means we're looking for three backslashes
+    // since we're looking for JSON encoded strings inside of our JSON encoded string
+    const isInJSON = subMatches[0].includes(`src=\\\\\\"`)
 
     return isHostedInWp && !isInJSON
   })

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -18,7 +18,6 @@ import fetchReferencedMediaItemsAndCreateNodes, {
 } from "../fetch-nodes/fetch-referenced-media-items"
 import btoa from "btoa"
 import store from "~/store"
-import { CREATED_NODE_IDS } from "~/constants"
 
 const imgSrcRemoteFileRegex = /(?:src=\\")((?:(?:https?|ftp|file):\/\/|www\.|ftp\.|\/)(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[A-Z0-9+&@#/%=~_|$])\.(?:jpeg|jpg|png|gif|ico|mpg|ogv|svg|bmp|tif|tiff))(?=\\"| |\.)/gim
 
@@ -624,8 +623,24 @@ const replaceNodeHtmlImages = async ({
         gatsbyImageStringJSON.length - 1
       )
 
-      // replace match with react string in nodeString
       nodeString = nodeString.replace(match, gatsbyImageString)
+
+      const jsonStringifiedMatch = JSON.stringify(match)
+      const jsonEscapedMatch = jsonStringifiedMatch.substring(
+        1,
+        jsonStringifiedMatch.length - 1
+      )
+
+      const matchGlobalRegex = new RegExp(jsonEscapedMatch, `gm`)
+
+      const matchInstances = execall(matchGlobalRegex, nodeString)
+
+      if (matchInstances.length) {
+        for (const { match: matchInstance } of matchInstances) {
+          // replace match with react string in nodeString
+          nodeString = nodeString.replace(matchInstance, gatsbyImageString)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 1.5.4

### Bug Fixes

- the `options.type[typename]type.beforeChangeNode` api was not running when creating all nodes, just when updating nodes. This now runs before all node updates (create, update, delete).
- When replacing images with Gatsby images in html fields, only the first instance of an image was being replaced if there were more than 1 identical HTML <img /> strings.