### PR TITLE
Feat: add media item parent error context and allow 404s in develop

### DIFF
--- a/.test-runtime/src/components/template-parts/blog-post.js
+++ b/.test-runtime/src/components/template-parts/blog-post.js
@@ -16,9 +16,9 @@ function BlogPost({ data }) {
         {title}
       </Heading>
 
-      {!!featuredImage?.node?.remoteFile?.childImageSharp && (
+      {!!featuredImage?.node?.localFile?.childImageSharp && (
         <Box mb={5}>
-          <Img fluid={featuredImage.node.remoteFile.childImageSharp.fluid} />
+          <Img fluid={featuredImage.node.localFile.childImageSharp.fluid} />
         </Box>
       )}
 

--- a/.test-runtime/src/templates/index.js
+++ b/.test-runtime/src/templates/index.js
@@ -18,11 +18,11 @@ export default ({ data, pageContext }) => (
               <Grid templateColumns="1fr 2fr" gap={6}>
                 <Box>
                   {!!page.featuredImage &&
-                    !!page.featuredImage.remoteFile &&
-                    !!page.featuredImage.remoteFile.childImageSharp && (
+                    !!page.featuredImage.localFile &&
+                    !!page.featuredImage.localFile.childImageSharp && (
                       <Img
                         fluid={
-                          page.featuredImage.remoteFile.childImageSharp.fluid
+                          page.featuredImage.localFile.childImageSharp.fluid
                         }
                       />
                     )}
@@ -107,7 +107,7 @@ export const query = graphql`
         title
         featuredImage {
           node {
-            remoteFile {
+            localFile {
               ...Thumbnail
             }
           }

--- a/.test-runtime/src/templates/single/Page.js
+++ b/.test-runtime/src/templates/single/Page.js
@@ -11,7 +11,7 @@ export const query = graphql`
       content
       featuredImage {
         node {
-          remoteFile {
+          localFile {
             ...HeroImage
           }
         }

--- a/.test-runtime/src/templates/single/Post.js
+++ b/.test-runtime/src/templates/single/Post.js
@@ -11,7 +11,7 @@ export const query = graphql`
       content
       featuredImage {
         node {
-          remoteFile {
+          localFile {
             ...HeroImage
           }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Upcoming
+
+### New Features
+
+- 404 images will no longer fail the build during `gatsby develop` but will continue to fail the build in production builds.
+- Media item fetch errors now include the name of the parent step in which the MediaItem File node was being fetched.
+
 ## 1.6.3
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - 404 images will no longer fail the build during `gatsby develop` but will continue to fail the build in production builds.
 - Media item fetch errors now include the name of the parent step in which the MediaItem File node was being fetched.
+- When fetching html media item files, non-404 error codes now return more helpful information about which media item is having the problem.
+- 404ing images in production now have an extra line to the error message explaining that the build failed to prevent deploying a broken site.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - 404 images will no longer fail the build during `gatsby develop` but will continue to fail the build in production builds.
 - Media item fetch errors now include the name of the parent step in which the MediaItem File node was being fetched.
 
+### Changes
+
+- MediaItem.remoteFile has been deprecated for a few months, querying for it now throws an error.
+
 ## 1.6.3
 
 ### Bug Fixes

--- a/src/models/gatsby-api.js
+++ b/src/models/gatsby-api.js
@@ -109,9 +109,6 @@ const defaultPluginOptions = {
           })
 
           if (createdMediaItem) {
-            remoteNode.remoteFile = {
-              id: createdMediaItem.id,
-            }
             remoteNode.localFile = {
               id: createdMediaItem.id,
             }

--- a/src/models/gatsby-api.js
+++ b/src/models/gatsby-api.js
@@ -102,7 +102,11 @@ const defaultPluginOptions = {
           }
         }
 
-        if (actionType === `CREATE` || actionType === `UPDATE`) {
+        if (
+          actionType === `CREATE_ALL` ||
+          actionType === `CREATE` ||
+          actionType === `UPDATE`
+        ) {
           const createdMediaItem = await createRemoteMediaItemNode({
             mediaItemNode: remoteNode,
             parentName: `Node action ${actionType}`,

--- a/src/models/gatsby-api.js
+++ b/src/models/gatsby-api.js
@@ -105,6 +105,7 @@ const defaultPluginOptions = {
         if (actionType === `CREATE` || actionType === `UPDATE`) {
           const createdMediaItem = await createRemoteMediaItemNode({
             mediaItemNode: remoteNode,
+            parentName: `Node action ${actionType}`,
           })
 
           if (createdMediaItem) {

--- a/src/steps/create-schema-customization/type-filters.js
+++ b/src/steps/create-schema-customization/type-filters.js
@@ -68,31 +68,10 @@ export const typeDefinitionFilters = [
       objectType.fields.remoteFile = {
         type: `File`,
         deprecationReason: `MediaItem.remoteFile was renamed to localFile`,
-        resolve: (mediaItemNode, _, context) => {
-          if (!mediaItemNode) {
-            return null
-          }
-
-          const remoteMediaNodeId =
-            mediaItemNode.remoteFile && mediaItemNode.remoteFile.id
-              ? mediaItemNode.remoteFile.id
-              : null
-
-          if (remoteMediaNodeId) {
-            const node = context.nodeModel.getNodeById({
-              id: mediaItemNode.remoteFile.id,
-              type: `File`,
-            })
-
-            if (node) {
-              return node
-            }
-          }
-
-          return createRemoteMediaItemNode({
-            mediaItemNode,
-            parentName: `Creating File node while resolving missing MediaItem.localFile`,
-          })
+        resolve: () => {
+          throw new Error(
+            `MediaItem.remoteFile is deprecated and has been renamed to MediaItem.localFile. Please update your code.`
+          )
         },
       }
 
@@ -118,6 +97,7 @@ export const typeDefinitionFilters = [
 
           return createRemoteMediaItemNode({
             mediaItemNode,
+            parentName: `Creating File node while resolving missing MediaItem.localFile`,
           })
         },
       }

--- a/src/steps/create-schema-customization/type-filters.js
+++ b/src/steps/create-schema-customization/type-filters.js
@@ -91,6 +91,7 @@ export const typeDefinitionFilters = [
 
           return createRemoteMediaItemNode({
             mediaItemNode,
+            parentName: `Creating File node while resolving missing MediaItem.localFile`,
           })
         },
       }

--- a/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -28,7 +28,35 @@ export const getMediaItemEditLink = (node) => {
   return editUrl
 }
 
-export const errorPanicker = ({ error, reporter, node }) => {
+export const errorPanicker = ({
+  error,
+  reporter,
+  node,
+  fetchState,
+  parentName,
+}) => {
+  const editUrl = getMediaItemEditLink(node)
+  const sharedError = `occured while fetching media item #${node.databaseId}${
+    parentName ? ` in step:\n\n"${parentName}"` : ``
+  }\n\nMedia item link: ${node.link}\nEdit link: ${editUrl}\nFile url: ${
+    node.mediaItemUrl
+  }`
+
+  if (
+    process.env.NODE_ENV !== `production` &&
+    error.includes(`Response code 404`)
+  ) {
+    fetchState.shouldBail = true
+    reporter.log(``)
+    reporter.warn(
+      formatLogMessage(
+        `Error ${sharedError}\n\nThis error will fail production builds.`
+      )
+    )
+    reporter.log(``)
+    return
+  }
+
   if (
     error.includes(`Response code 4`) ||
     error.includes(`Response code 500`) ||
@@ -37,14 +65,8 @@ export const errorPanicker = ({ error, reporter, node }) => {
     error.includes(`Response code 505`) ||
     error.includes(`Response code 501`)
   ) {
-    const editUrl = getMediaItemEditLink(node)
-
     reporter.log(``)
-    reporter.info(
-      formatLogMessage(
-        `Unrecoverable error occured while fetching media item #${node.databaseId}\n\nMedia item link: ${node.link}\nEdit link: ${editUrl}\nFile url: ${node.mediaItemUrl}`
-      )
-    )
+    reporter.info(formatLogMessage(`Unrecoverable error ${sharedError}`))
     reporter.panic(error)
   }
 }
@@ -95,6 +117,7 @@ export const getFileNodeByMediaItemNode = async ({
 export const createRemoteMediaItemNode = async ({
   mediaItemNode,
   fixedBarTotal,
+  parentName,
 }) => {
   const state = store.getState()
   const { helpers, pluginOptions } = state.gatsbyApi
@@ -144,9 +167,16 @@ export const createRemoteMediaItemNode = async ({
     (process.env.NODE_ENV === `production` &&
       pluginOptions.production.hardCacheMediaFiles)
 
+  let fetchState = {
+    shouldBail: false,
+  }
   // Otherwise we need to download it
   const remoteFileNode = await retry(
     async () => {
+      if (fetchState.shouldBail) {
+        return null
+      }
+
       const createFileNodeRequirements = {
         parentNodeId: mediaItemNode.id,
         store: gatsbyStore,
@@ -209,9 +239,19 @@ export const createRemoteMediaItemNode = async ({
       factor: 1.1,
       minTimeout: 5000,
       onRetry: (error) =>
-        errorPanicker({ error, reporter, node: mediaItemNode }),
+        errorPanicker({
+          error,
+          reporter,
+          node: mediaItemNode,
+          fetchState,
+          parentName,
+        }),
     }
   )
+
+  if (!remoteFileNode) {
+    return null
+  }
 
   // push it's id and url to our store for caching,
   // so we can touch this node next time

--- a/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -66,7 +66,11 @@ export const errorPanicker = ({
     error.includes(`Response code 501`)
   ) {
     reporter.log(``)
-    reporter.info(formatLogMessage(`Unrecoverable error ${sharedError}`))
+    reporter.info(
+      formatLogMessage(
+        `Unrecoverable error ${sharedError}\n\nFailing the build to prevent deploying a broken site.`
+      )
+    )
     reporter.panic(error)
   }
 }

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -249,24 +249,23 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
           createNode: helpers.actions.createNode,
         })
       } catch (e) {
+        const sharedError = `when trying to fetch\n${htmlImgSrc}\nfrom ${
+          node.__typename
+        } #${node.databaseId} "${node.title ?? node.id}"`
+        const nodeEditLink = getNodeEditLink(node)
+
         if (typeof e === `string` && e.includes(`404`)) {
-          const nodeEditLink = getNodeEditLink(node)
           helpers.reporter.log(``)
           helpers.reporter.warn(
             formatLogMessage(
-              `\n\nReceived a 404 when trying to fetch\n${htmlImgSrc}\nfrom ${
-                node.__typename
-              } #${node.databaseId} "${
-                node.title ?? node.id
-              }"\n\nMost likely this image was uploaded to this ${
-                node.__typename
-              } and then deleted from the media library.\nYou'll need to fix this and re-save this ${
-                node.__typename
-              } to remove this warning at\n${nodeEditLink}.\n\n`
+              `\n\nReceived a 404 ${sharedError}\n\nMost likely this image was uploaded to this ${node.__typename} and then deleted from the media library.\nYou'll need to fix this and re-save this ${node.__typename} to remove this warning at\n${nodeEditLink}.\n\n`
             )
           )
           imageNode = null
         } else {
+          helpers.reporter.warn(
+            `Received the below error ${sharedError}\n\n${nodeEditLink}\n\n`
+          )
           helpers.reporter.panic(formatLogMessage(e))
         }
       }

--- a/src/steps/source-nodes/create-nodes/process-node.js
+++ b/src/steps/source-nodes/create-nodes/process-node.js
@@ -727,12 +727,16 @@ const replaceFileLinks = async ({
           }) => mediaItemNode.mediaItemUrl.includes(path)
         )?.matchGroup
 
+        if (!mediaItemMatchGroup) {
+          return
+        }
+
         const [
           _delimiterOpen,
           hostname,
           path,
           _delimiterClose,
-        ] = mediaItemMatchGroup.subMatches
+        ] = mediaItemMatchGroup?.subMatches
 
         cacheCreatedFileNodeBySrc({
           node: mediaItemNode,

--- a/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -109,6 +109,7 @@ export const createMediaItemNode = async ({
   createContentDigest,
   actions,
   referencedMediaItemNodeIds,
+  parentName,
   allMediaItemNodes = [],
 }) => {
   const existingNode = await helpers.getNode(node.id)
@@ -148,6 +149,7 @@ export const createMediaItemNode = async ({
         mediaItemNode: node,
         fixedBarTotal: referencedMediaItemNodeIds?.length,
         helpers,
+        parentName,
       })
 
       if (timesRetried > 1) {
@@ -372,6 +374,7 @@ const fetchMediaItemsBySourceUrl = async ({
               createContentDigest,
               actions,
               allMediaItemNodes,
+              parentName: `Fetching referenced MediaItem nodes by sourceUrl`,
             })
           )
         )
@@ -475,6 +478,7 @@ const fetchMediaItemsById = async ({
               actions,
               allMediaItemNodes,
               referencedMediaItemNodeIds: mediaItemIds,
+              parentName: `Fetching referenced MediaItem nodes by id`,
             })
           )
         )

--- a/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -164,9 +164,6 @@ export const createMediaItemNode = async ({
 
       node = {
         ...node,
-        remoteFile: {
-          id: localFileNode.id,
-        },
         localFile: {
           id: localFileNode.id,
         },

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -254,6 +254,7 @@ export const restoreHardCachedNodes = async ({ hardCachedNodes }) => {
           helpers,
           createContentDigest,
           actions,
+          parentName: `Hard cache restoration`,
           // referencedMediaItemNodeIds,
           // allMediaItemNodes = [],
         })


### PR DESCRIPTION
Closes #206 and #70

### New Features

- 404 images will no longer fail the build during `gatsby develop` but will continue to fail the build in production builds.
- Media item fetch errors now include the name of the parent step in which the MediaItem File node was being fetched.
- When fetching html media item files, non-404 error codes now return more helpful information about which media item is having the problem.
- 404ing images in production now have an extra line to the error message explaining that the build failed to prevent deploying a broken site.

### Changes

- MediaItem.remoteFile has been deprecated for a few months, querying for it now throws an error.