### PR TITLE
check isWpGatsby first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.7.7
+
+Moved the check for wether the remote API is using WPGatsby or not to make it more consistent. It was running in parallel with some other checks and sometimes the others would finish first producing incorrect error messages.
+
+In `src/steps/check-plugin-requirements.js`, `isWpGatsby()`
+
 ## 1.7.6
 
 - There was a timing issue in that if 'fetchMediaItemsById' (steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"
   },

--- a/src/steps/check-plugin-requirements.js
+++ b/src/steps/check-plugin-requirements.js
@@ -281,9 +281,9 @@ const ensurePluginRequirementsAreMet = async (helpers, _pluginOptions) => {
   }
 
   await blankGetRequest({ url, helpers })
+  await isWpGatsby()
 
   await Promise.all([
-    isWpGatsby(),
     prettyPermalinksAreEnabled({ helpers }),
     areRemotePluginVersionsSatisfied({
       helpers,


### PR DESCRIPTION
@acao fyi I moved the isWpGatsby check here because it turns out the order of checks here matters to get reliable errors 😱 

Related to https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues/132

