### PR TITLE
chore: when checking coverage, preprocessor fails on transforming typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 public
 .cache
 plugin/README.md
+coverage

--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,5 +1,11 @@
-const babelOptions = {
-  presets: [`babel-preset-gatsby`],
-}
-
-module.exports = require(`babel-jest`).createTransformer(babelOptions)
+const babelPreset = require(`./babel.config.js`)
+module.exports = require(`babel-jest`).createTransformer({
+  ...babelPreset,
+  overrides: [
+    ...(babelPreset.overrides || []),
+    {
+      test: [`**/*.ts`, `**/*.tsx`],
+      plugins: [[`@babel/plugin-transform-typescript`, { isTSX: true }]],
+    },
+  ],
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   transform: {
-    "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`,
+    "^.+\\.[jt]sx?$": `<rootDir>/jest-preprocess.js`,
   },
   // moduleNameMapper: {
   //   ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
@@ -16,4 +16,6 @@ module.exports = {
   globalSetup: `./test-site/test-utils/global-setup-jest.js`,
   globalTeardown: `./test-site/test-utils/global-teardown-jest.js`,
   setupFilesAfterEnv: [`./test-site/test-utils/jest.setup.js`],
+  collectCoverageFrom: [`plugin/src/**/*`],
+  moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],
 }


### PR DESCRIPTION
when running jest with `--coverage` in the repo (after configuring it to collect coverage from the plugin in this PR), i see this:
![image](https://user-images.githubusercontent.com/1368727/97594532-2720f100-19d9-11eb-9160-26ed8b77a68e.png)

this is taken from the gatsby monorepo, and ensures we can transform typescript properly when parsing it, though we don't have suites we can collect coverage from yet.