### PR TITLE
fix: blue text works better across themes instead of blue background

### DIFF
--- a/plugin/src/utils/format-log-message.js
+++ b/plugin/src/utils/format-log-message.js
@@ -16,7 +16,7 @@ const formatLogMessage = (input, { useVerboseStyle } = {}) => {
   }
 
   return verbose || useVerboseStyle
-    ? `${chalk.bgBlue.white(` gatsby-source-wordpress `)} ${message}`
+    ? `${chalk.blue(` gatsby-source-wordpress `)} ${message}`
     : `[gatsby-source-wordpress] ${message}`
 }
 


### PR DESCRIPTION
Current style: 

<img width="911" alt="Screen Shot 2020-11-10 at 2 51 12 PM" src="https://user-images.githubusercontent.com/14190743/98743102-5aae3480-2364-11eb-8cd9-3381f4e1a2fc.png">

<img width="912" alt="Screen Shot 2020-11-10 at 2 51 22 PM" src="https://user-images.githubusercontent.com/14190743/98743121-600b7f00-2364-11eb-8a1b-01e77caa7ea0.png">

New style:

<img width="910" alt="Screen Shot 2020-11-10 at 2 59 36 PM" src="https://user-images.githubusercontent.com/14190743/98743736-61897700-2365-11eb-8e83-c29d2918a684.png">

<img width="906" alt="Screen Shot 2020-11-10 at 2 50 15 PM" src="https://user-images.githubusercontent.com/14190743/98743179-73b6e580-2364-11eb-8689-3c157ceae5c0.png">
