### PR TITLE
Feat: add max filesize option

### DIFF
--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -35,6 +35,7 @@
     - [type.RootQuery: Object](#typerootquery-object)
     - [type.MediaItem.lazyNodes: Boolean](#typemediaitemlazynodes-boolean)
     - [type.MediaItem.localFile.excludeByMimeTypes: Array](#typemediaitemlocalfileexcludebymimetypes-array)
+    - [type.MediaItem.localFile.maxFileSizeBytes: Number](#typemediaitemlocalfilemaxfilesizebytes-number)
 - [Up Next :point_right:](#up-next-point_right)
 
 ## url: String
@@ -613,6 +614,27 @@ Default is `[]`.
       MediaItem: {
         localFile: {
           excludeByMimeTypes: [`video/mp4`]
+        },
+      },
+    },
+  },
+},
+```
+
+### type.MediaItem.localFile.maxFileSizeBytes: Number
+
+Allows preventing the download of files that are above a certain file size (in bytes).
+
+Default is `10485760` which is 10Mb.
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    type: {
+      MediaItem: {
+        localFile: {
+          maxFileSizeBytes: 10485760
         },
       },
     },

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -625,7 +625,7 @@ Default is `[]`.
 
 Allows preventing the download of files that are above a certain file size (in bytes).
 
-Default is `10485760` which is 10Mb.
+Default is `15728640` which is 15Mb.
 
 ```js
 {
@@ -634,7 +634,7 @@ Default is `10485760` which is 10Mb.
     type: {
       MediaItem: {
         localFile: {
-          maxFileSizeBytes: 10485760
+          maxFileSizeBytes: 10485760 // 10Mb
         },
       },
     },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -23,6 +23,7 @@
     "execall": "^2.0.0",
     "fast-json-stable-stringify": "^2.1.0",
     "file-type": "^15.0.1",
+    "filesize": "^6.1.0",
     "fs-extra": "^9.0.1",
     "gatsby-core-utils": "^1.3.20",
     "gatsby-image": "^2.4.14",

--- a/plugin/src/models/gatsby-api.js
+++ b/plugin/src/models/gatsby-api.js
@@ -93,7 +93,7 @@ const defaultPluginOptions = {
       lazyNodes: false,
       localFile: {
         excludeByMimeTypes: [],
-        maxFileSizeBytes: 10485760, // 10Mb
+        maxFileSizeBytes: 15728640, // 15Mb
       },
       beforeChangeNode: async ({ remoteNode, actionType, typeSettings }) => {
         // we fetch lazy nodes files in resolvers, no need to fetch them here.

--- a/plugin/src/models/gatsby-api.js
+++ b/plugin/src/models/gatsby-api.js
@@ -93,6 +93,7 @@ const defaultPluginOptions = {
       lazyNodes: false,
       localFile: {
         excludeByMimeTypes: [],
+        maxFileSizeBytes: 10485760, // 10Mb
       },
       beforeChangeNode: async ({ remoteNode, actionType, typeSettings }) => {
         // we fetch lazy nodes files in resolvers, no need to fetch them here.

--- a/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -144,7 +144,7 @@ export const createRemoteMediaItemNode = async ({
     actions: { createNode },
   } = helpers
 
-  let { mediaItemUrl, modifiedGmt, mimeType, title } = mediaItemNode
+  let { mediaItemUrl, modifiedGmt, mimeType, title, fileSize } = mediaItemNode
 
   if (!mediaItemUrl) {
     return null
@@ -153,7 +153,15 @@ export const createRemoteMediaItemNode = async ({
   const { wpUrl } = state.remoteSchema
   mediaItemUrl = ensureSrcHasHostname({ wpUrl, src: mediaItemUrl })
 
-  const { excludeByMimeTypes } = pluginOptions.type?.MediaItem?.localFile
+  const {
+    excludeByMimeTypes,
+    maxFileSizeBytes,
+  } = pluginOptions.type?.MediaItem?.localFile
+
+  // if this file is larger than maxFileSizeBytes, don't fetch the remote file
+  if (fileSize > maxFileSizeBytes) {
+    return null
+  }
 
   // if this type of file is excluded, don't fetch the remote file
   if (excludeByMimeTypes.includes(mimeType)) {


### PR DESCRIPTION
When creating a starter and using the official WP theme unit test data (which includes a 30 mb video file) I was completely unable to run a build because files this large take a very long time for Gatsby to download. I have Gigabit internet and the file downloads in a second via the browser but because Gatsby can't handle files this large very well, it kept timing out and retrying before eventually failing the build.
This new option `maxFileSizeBytes` adds a configurable max file size beyond which Gatsby will not try to fetch and process the remote file.

I'm pushing this through as a bug fix because knowing how fast my internet is, this appears to simply be a current Gatsby limitation. This will not be considered a breaking change for folks and will likely unblock folks who appear to have a frozen build process.