### PR TITLE
feat: test /graphql in case provided url fails

### DIFF
--- a/plugin/src/utils/fetch-graphql.js
+++ b/plugin/src/utils/fetch-graphql.js
@@ -358,7 +358,9 @@ ${slackChannelSupportMessage}`
           id: CODES.missingAppendedPath,
           context: {
             sourceMessage: formatLogMessage(
-              `${errorContext}\n\nThe supplied url ${chalk.bold(
+              `${
+                errorContext ? `${errorContext}` : ``
+              }\n\nThe supplied url ${chalk.bold(
                 urlWithoutTrailingSlash
               )} is invalid,\nhowever ${chalk.bold(
                 urlWithoutTrailingSlash + `/graphql`

--- a/plugin/src/utils/fetch-graphql.js
+++ b/plugin/src/utils/fetch-graphql.js
@@ -345,14 +345,18 @@ ${slackChannelSupportMessage}`
     }
     try {
       const urlWithoutTrailingSlash = url.replace(/\/$/, ``)
+
       const response = await http.post(
         [urlWithoutTrailingSlash, `/graphql`].join(``),
         { query, variables },
         requestOptions
       )
+
       const contentType = response?.headers[`content-type`]
+
       if (contentType?.includes(`application/json;`)) {
         const docsLink = `https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/plugin-options.md#url-string`
+
         // if adding `/graphql` works, panic with a useful message
         reporter.panic({
           id: CODES.missingAppendedPath,

--- a/plugin/src/utils/report.js
+++ b/plugin/src/utils/report.js
@@ -41,4 +41,9 @@ export const ERROR_MAP = {
     level: `ERROR`,
     category: `THIRD_PARTY`,
   },
+  [CODES.MissingAppendedPath]: {
+    text: (context) => context.sourceMessage,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
 }

--- a/plugin/src/utils/report.js
+++ b/plugin/src/utils/report.js
@@ -8,6 +8,7 @@ export const CODES = {
 
   /* GraphQL Errors */
   RemoteGraphQLError: `112001`,
+  MissingAppendedPath: `112002`,
 }
 
 export const ERROR_MAP = {


### PR DESCRIPTION
if we get an HTML response when checking whether the schema URL is valid, we make a more minimal, successive request that tests appending `/graphql` to the URL. it either throws an error that instructs the user to update their config, or it fails quietly and goes on to handle the HTML response as before.