### PR TITLE
Fix: WP node delete action can fail when type is excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.3.1
+
+- Deleting a post in WordPress which had been excluded in plugin options in Gatsby would fail the build previously. There are now checks in place that prevent and info about what's happening is logged to the terminal output.
+
 ## 2.3.0
 
 - Added a check where if html is returned from the GraphQL endpoint, we append `/graphql` to the url and try again. If that returns JSON, we panic and display an error telling the developer to update the url to include `/graphql`. Thanks @acao!!

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/delete.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/delete.js
@@ -30,14 +30,13 @@ const wpActionDELETE = async ({
       getQueryInfoBySingleFieldName(wpAction.referencedNodeSingularName) || {}
 
     if (!typeInfo) {
-      Object.entries(wpAction).forEach(([key, value]) =>
-        reporter.warn(`${key} -> ${value}`)
-      )
-      reporter.panic(
+      reporter.info(
         formatLogMessage(
-          `Unable to perform above action. Data may be unsynched. Clear your cache and run the build process again to resync all data.`
+          `A ${wpAction.referencedNodeSingularName} was deleted, but this node type is excluded in plugin options.`
         )
       )
+      reporter.log(``)
+      return
     }
 
     const typeSettings = getTypeSettingsByType({

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -68,14 +68,12 @@ export const fetchAndCreateSingleNode = async ({
   } = getGatsbyApi()
 
   if (!query) {
-    reporter.log(``)
-    reporter.warn(
+    reporter.info(
       formatLogMessage(
-        `A ${singleName} was updated, but no query was found for this node type.`
+        `A ${singleName} was updated, but this node type is excluded in plugin options.`
       )
     )
     reporter.log(``)
-
     return { node: null }
   }
 

--- a/starters/gatsby-starter-wordpress-blog/gatsby-config.js
+++ b/starters/gatsby-starter-wordpress-blog/gatsby-config.js
@@ -26,7 +26,9 @@ module.exports = {
       resolve: `gatsby-source-wordpress-experimental`,
       options: {
         // the only required plugin option for WordPress is the GraphQL url.
-        url: `https://wpgatsbydemo.wpengine.com/graphql`,
+        url:
+          process.env.WPGRAPHQL_URL ||
+          `https://wpgatsbydemo.wpengine.com/graphql`,
       },
     },
 


### PR DESCRIPTION
Closes #105 