### PR TITLE
Fix: only run preview logic in preview mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 public
 .cache
 plugin/README.md
+
+.inc-builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.0.2
+
+- Incremental builds were not properly fetching delta updates because the inc builds runner keeps around plugin state, and this plugin was assuming it didn't.
+- ENABLE_GATSBY_REFRESH_ENDPOINT was being used to determine wether or not we were in preview mode. Inc builds also uses this env variable which was causing problems. We now track wether we're in preview mode using internal state instead.
+- `updateSchema` was being called outside development which was causing problems where it would freeze Gatsby's state machine. This was only meant to be called in development and so has been scoped to NODE_ENV=development. 
+
 ## 3.0.1
 
 - Logs `got` HTTPErrors before rejecting because in some cases this error appeared to be completely swallowed somewhere before our `errorPanicker` function could access it.

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"
   },

--- a/plugin/src/models/preview.ts
+++ b/plugin/src/models/preview.ts
@@ -8,6 +8,7 @@ interface StoredPage {
 }
 
 interface IPreviewState {
+  inPreviewMode: boolean
   nodePageCreatedCallbacks: {
     [nodeId: string]: OnPageCreatedCallback
   }
@@ -55,12 +56,19 @@ interface IPreviewStore {
 
 const previewStore: IPreviewStore = {
   state: {
+    inPreviewMode: false,
     nodePageCreatedCallbacks: {},
     nodeIdsToCreatedPages: {},
     pagePathToNodeDependencyId: {},
   },
 
   reducers: {
+    setInPreviewMode(state, inPreviewMode) {
+      state.inPreviewMode = inPreviewMode
+
+      return state
+    },
+
     unSubscribeToPagesCreatedFromNodeById(state, { nodeId }) {
       if (state.nodePageCreatedCallbacks?.[nodeId]) {
         delete state.nodePageCreatedCallbacks[nodeId]

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -1,3 +1,4 @@
+import { inPreviewMode } from "."
 import { OnPageCreatedCallback } from "~/models/preview"
 import store from "~/store"
 
@@ -12,12 +13,20 @@ import store from "~/store"
  */
 export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
   void
-> =>
+> => {
+  if (!inPreviewMode()) {
+    return invokeAndCleanupLeftoverPreviewCallbacks({
+      status: `GATSBY_PREVIEW_PROCESS_ERROR`,
+      context: `Gatsby is not in Preview mode.`,
+    })
+  }
+
   // check for any onCreatePageCallbacks that weren't called during createPages
   // we need to tell WP that a page wasn't created for the preview
-  invokeAndCleanupLeftoverPreviewCallbacks({
+  return invokeAndCleanupLeftoverPreviewCallbacks({
     status: `NO_PAGE_CREATED_FOR_PREVIEWED_NODE`,
   })
+}
 
 export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
   status,

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -11,7 +11,8 @@ import { touchValidNodes } from "../source-nodes/update-nodes/fetch-node-updates
 import { IPluginOptions } from "~/models/gatsby-api"
 
 export const inPreviewMode = (): boolean =>
-  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT &&
+  !!store.getState().previewStore.inPreviewMode
 
 type PreviewStatusUnion =
   | `PREVIEW_SUCCESS`
@@ -164,6 +165,8 @@ export const sourcePreviews = async (
       )
     )
   }
+
+  store.dispatch.previewStore.setInPreviewMode(true)
 
   // this callback will be invoked when the page is created/updated for this node
   // then it'll send a mutation to WPGraphQL so that WP knows the preview is ready

--- a/plugin/src/steps/source-nodes/index.js
+++ b/plugin/src/steps/source-nodes/index.js
@@ -13,6 +13,7 @@ const sourceNodes = async (helpers, pluginOptions) => {
 
   if (webhookBody.preview) {
     await sourcePreviews(helpers, pluginOptions)
+
     return
   }
 
@@ -50,6 +51,8 @@ const sourceNodes = async (helpers, pluginOptions) => {
   await nonNodeRootFieldsPromise
 
   allowFileDownloaderProgressBarToClear()
+
+  store.dispatch.remoteSchema.setSchemaWasChanged(false)
 }
 
 export { sourceNodes }

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -57,6 +57,7 @@ export const updateSchema = async (args = {}) => {
   })
 
   store.dispatch.remoteSchema.toggleAllowRefreshSchemaUpdate()
+  store.dispatch.remoteSchema.setSchemaWasChanged(false)
 }
 
 export const fetchAndCreateSingleNode = async ({

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -99,24 +99,27 @@ export const fetchAndCreateSingleNode = async ({
         `A ${singleName} was updated, but this node type is excluded in plugin options.`
       )
     )
-    reporter.info(
-      formatLogMessage(
-        `Re-running createSchemaCustomization to check for updates.`
+
+    if (process.env.NODE_ENV === `development`) {
+      reporter.info(
+        formatLogMessage(
+          `Re-running createSchemaCustomization to check for updates.`
+        )
       )
-    )
 
-    await updateSchema()
+      await updateSchema()
 
-    // now that the queries have updated, grab the latest query for this node
-    query = getNodeQuery()
+      // now that the queries have updated, grab the latest query for this node
+      query = getNodeQuery()
 
-    if (!query) {
-      reporter.log(``)
-      reporter.warn(
-        formatLogMessage(`Still couldn't find a query for ${singleName}.`)
-      )
-      reporter.log(``)
-      return { node: null }
+      if (!query) {
+        reporter.log(``)
+        reporter.warn(
+          formatLogMessage(`Still couldn't find a query for ${singleName}.`)
+        )
+        reporter.log(``)
+        return { node: null }
+      }
     }
   }
 
@@ -149,7 +152,11 @@ export const fetchAndCreateSingleNode = async ({
     // first we try to fetch and throw gql errors
     // the reason for this is we can catch those errors,
     // diff the schema, and regenerate our gql queries if needed
-    data = await fetchNodeData({ throwGqlErrors: true })
+    // only do this in development though. In production we need to fail the build.
+    // in production the schema has already been diffed, so if it fails here, something else is afoot
+    data = await fetchNodeData({
+      throwGqlErrors: !!process.env.NODE_ENV === `development`,
+    })
   } catch (e) {
     reporter.log(``)
     reporter.warn(


### PR DESCRIPTION
## 3.0.2

- Incremental builds were not properly fetching delta updates because the inc builds runner keeps around plugin state, and this plugin was assuming it didn't.
- ENABLE_GATSBY_REFRESH_ENDPOINT was being used to determine wether or not we were in preview mode. Inc builds also uses this env variable which was causing problems. We now track wether we're in preview mode using internal state instead.
- `updateSchema` was being called outside development which was causing problems where it would freeze Gatsby's state machine. This was only meant to be called in development and so has been scoped to NODE_ENV=development. 