### PR TITLE
feature: seperate plugin options for concurrency limits, better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.2
 
-- replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content, and `type.MediaItem.localFile.requestConcurrency` for media items.
+- replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content via graphql (default: 10), and `type.MediaItem.localFile.requestConcurrency` for media items (default: 100).
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## 3.3.2
+## 4.0.0
+
+### Breaking Changes
 
 - replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content via graphql (default: 10), and `type.MediaItem.localFile.requestConcurrency` for media items (default: 100).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 3.3.2
+
 - replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content, and `type.MediaItem.localFile.requestConcurrency` for media items.
 
 ## 3.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.3.2
+- replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content, and `type.MediaItem.localFile.requestConcurrency` for media items.
+
 ## 3.3.1
 
 - Preview errors for brand new draft posts were not being passed back to Gatsby properly. This is now fixed :)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- replace usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content via graphql (default: 10), and `type.MediaItem.localFile.requestConcurrency` for media items (default: 100).
+- replaced usage of `GATSBY_CONCURRENT_REQUEST` with two seperate plugin options: `schema.requestConcurrency` for fetching content via graphql (default: 15), and `type.MediaItem.localFile.requestConcurrency` for media items (default: 100). If you were previously using `GATSBY_CONCURRENT_REQUEST` to limit either the request concurrency of either of these things, you'll need to use one of these new plugin options.
 
 ## 3.3.1
 

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -29,7 +29,7 @@ To run tests and do development work with this repo, you'll need:
 - `yarn test-build-watch` will watch the build integration suite
 - `yarn test-update` will run `-u` for all schema and build integration suites.
 
-### Changing wordpress plugin versions
+### Changing WordPress plugin versions
 
 if you're bumping plugin versions, you can:
 

--- a/docs/debugging-and-troubleshooting.md
+++ b/docs/debugging-and-troubleshooting.md
@@ -1,13 +1,15 @@
 # Debugging and Troubleshooting
 
-- [Node sourcing](#node-sourcing)
-  - [Missing data in Gatsby](#missing-data-in-gatsby)
-  - [GraphQL errors](#node-sourcing-graphql-errors)
-  - [WordPress 50\* errors](#wordpress-50-errors)
-  - [Timeouts](#node-sourcing-timeouts)
-- [Media File Download Errors](#media-file-download-errors)
-- [Broken Preview templates](#broken-preview-templates)
-- [Previews don't update](#previews-dont-update)
+- [Debugging and Troubleshooting](#debugging-and-troubleshooting)
+  - [Node sourcing](#node-sourcing)
+    - [Missing data in Gatsby](#missing-data-in-gatsby)
+    - [Node Sourcing GraphQL errors](#node-sourcing-graphql-errors)
+    - [WordPress 50\* errors](#wordpress-50-errors)
+    - [Node Sourcing Timeouts](#node-sourcing-timeouts)
+  - [Media File Download Errors](#media-file-download-errors)
+  - [Broken Preview templates](#broken-preview-templates)
+  - [Previews Don't Update](#previews-dont-update)
+- [Up Next :point_right:](#up-next-point_right)
 
 ## Node sourcing
 
@@ -118,7 +120,9 @@ You can use this query to reproduce your error message and debug your error mess
 
 ### WordPress 50\* errors
 
-If you're running into these errors during node sourcing, the plugin may be trying to fetch more data from your WordPress instance than your WP server can handle. Try lowering the [`schema.perPage`](./plugin-options.md#schema.perpage-int) plugin option from it's default of 100 and re-run your build process. If you still get errors, try setting this very low to rule out wether or not this is your problem.
+If you're running into these errors during node sourcing, the plugin may be trying to fetch more data from your WordPress instance than your WP server can handle. Try lowering the [`schema.perPage`](./plugin-options.md#schema.perpage-int) plugin option from it's default of 100 and re-run your build process.
+
+You can also try setting [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) to limit the amount of GraphQL requests made per second from the default of 50.
 
 Another reason this can happen is that one of your GraphQL queries causes an unrecoverable error on your WordPress server. See the section on [debugging GraphQL errors](#graphql-errors) for debugging steps.
 

--- a/docs/debugging-and-troubleshooting.md
+++ b/docs/debugging-and-troubleshooting.md
@@ -122,7 +122,7 @@ You can use this query to reproduce your error message and debug your error mess
 
 If you're running into these errors during node sourcing, the plugin may be trying to fetch more data from your WordPress instance than your WP server can handle. Try lowering the [`schema.perPage`](./plugin-options.md#schema.perpage-int) plugin option from it's default of 100 and re-run your build process.
 
-You can also try changing the [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) option to limit the amount of GraphQL requests concurrent GraphQL requests made at any time when sourcing data from WPGraphQL. It's default is 10 concurrent requests.
+You can also try changing the [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) option to limit the amount of GraphQL requests concurrent GraphQL requests made at any time when sourcing data from WPGraphQL. It's default is 15 concurrent requests.
 
 Another reason this can happen is that one of your GraphQL queries causes an unrecoverable error on your WordPress server. See the section on [debugging GraphQL errors](#graphql-errors) for debugging steps.
 

--- a/docs/debugging-and-troubleshooting.md
+++ b/docs/debugging-and-troubleshooting.md
@@ -122,7 +122,7 @@ You can use this query to reproduce your error message and debug your error mess
 
 If you're running into these errors during node sourcing, the plugin may be trying to fetch more data from your WordPress instance than your WP server can handle. Try lowering the [`schema.perPage`](./plugin-options.md#schema.perpage-int) plugin option from it's default of 100 and re-run your build process.
 
-You can also try setting [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) to limit the amount of GraphQL requests made per second from the default of 10.
+You can also try changing the [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) option to limit the amount of GraphQL requests concurrent GraphQL requests made at any time when sourcing data from WPGraphQL. It's default is 10 concurrent requests.
 
 Another reason this can happen is that one of your GraphQL queries causes an unrecoverable error on your WordPress server. See the section on [debugging GraphQL errors](#graphql-errors) for debugging steps.
 
@@ -153,7 +153,7 @@ Note that `GATSBY_CONCURRENCT_DOWNLOAD` has been retired, now [`schema.requestCo
 
 ## Media File Download Errors
 
-The main error that occurs while fetching media files is overwhelming the remote server due to too many concurrent requests. You can set the [`schema.requestConcurrecy`](./plugin-options.md#schema.requestconcurrency-int) plugin option below it's default of `10`. You will need to experiment a bit to determine what the maximum number of concurrent requests for media files your server can handle is.
+The main error that occurs while fetching media files is overwhelming the remote server due to too many concurrent requests. You can set the [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) plugin option below it's default of `100`. You will need to experiment a bit to determine what the maximum number of concurrent requests for media files your server can handle is.
 
 ## Broken Preview templates
 

--- a/docs/debugging-and-troubleshooting.md
+++ b/docs/debugging-and-troubleshooting.md
@@ -122,13 +122,13 @@ You can use this query to reproduce your error message and debug your error mess
 
 If you're running into these errors during node sourcing, the plugin may be trying to fetch more data from your WordPress instance than your WP server can handle. Try lowering the [`schema.perPage`](./plugin-options.md#schema.perpage-int) plugin option from it's default of 100 and re-run your build process.
 
-You can also try setting [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) to limit the amount of GraphQL requests made per second from the default of 50.
+You can also try setting [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) to limit the amount of GraphQL requests made per second from the default of 10.
 
 Another reason this can happen is that one of your GraphQL queries causes an unrecoverable error on your WordPress server. See the section on [debugging GraphQL errors](#graphql-errors) for debugging steps.
 
 ### Node Sourcing Timeouts
 
-If you're running into timeouts during node sourcing, it is likely that your WordPress server is limiting the number of concurrent requests to a number lower than the number of different types that this source plugin is attempting to source from your WordPress server. You can either increase the number of concurrent connections your WordPress server can handle by tuning or replacing your server, or you can lower the env variable `GATSBY_CONCURRENT_DOWNLOAD` to a lower number than the number of concurrent GraphQL requests your WordPress server can handle.
+If you're running into timeouts during node sourcing, it is likely that your WordPress server is limiting the number of concurrent requests to a number lower than the number of different types that this source plugin is attempting to source from your WordPress server. You can either increase the number of concurrent connections your WordPress server can handle by tuning or replacing your server, or you can lower the plugin option [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) to a lower number than the number of concurrent GraphQL requests your WordPress server can handle.
 
 To determine how many concurrent GraphQL requests your server can handle, enable verbose mode with the `verbose` plugin option:
 
@@ -149,11 +149,11 @@ You will see that at the bottom of the list there are some types which aren't ye
 
 Count upwards from the last type that seems to be frozen to the top of the list. This is the number of concurrent GraphQL requests your server can handle.
 
-Follow this Gatsby guide on [setting environment variables](https://www.gatsbyjs.org/docs/environment-variables/) to set the `GATSBY_CONCURRENT_DOWNLOAD` env variable to this number.
+Note that `GATSBY_CONCURRENCT_DOWNLOAD` has been retired, now [`schema.requestConcurrency`](./plugin-options.md#schema.requestconcurrency-int) plugin option is used.
 
 ## Media File Download Errors
 
-The main error that occurs while fetching media files is overwhelming the remote server due to too many concurrent requests. Follow this Gatsby guide on [setting environment variables](https://www.gatsbyjs.org/docs/environment-variables/) to set the `GATSBY_CONCURRENT_DOWNLOAD` env variable below it's default of `200`. You will need to experiment a bit to determine what the maximum number of concurrent requests for media files your server can handle is. I like to first drop it to `100` and if it works I will raise it to `150` and try again and adjust. If `100` still fails, I would try setting it very low to `10` and raising the number from there until you find the maximum.
+The main error that occurs while fetching media files is overwhelming the remote server due to too many concurrent requests. You can set the [`schema.requestConcurrecy`](./plugin-options.md#schema.requestconcurrency-int) plugin option below it's default of `10`. You will need to experiment a bit to determine what the maximum number of concurrent requests for media files your server can handle is.
 
 ## Broken Preview templates
 

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -36,6 +36,7 @@
     - [type.MediaItem.lazyNodes: Boolean](#typemediaitemlazynodes-boolean)
     - [type.MediaItem.localFile.excludeByMimeTypes: Array](#typemediaitemlocalfileexcludebymimetypes-array)
     - [type.MediaItem.localFile.maxFileSizeBytes: Number](#typemediaitemlocalfilemaxfilesizebytes-number)
+    - [type.MediaItem.localFile.requestConcurrency: Number](#typemediaitemlocalfilerequestconcurrency-number)
 - [Up Next :point_right:](#up-next-point_right)
 
 ## url: String
@@ -635,6 +636,25 @@ Default is `15728640` which is 15Mb.
       MediaItem: {
         localFile: {
           maxFileSizeBytes: 10485760 // 10Mb
+        },
+      },
+    },
+  },
+},
+```
+
+### type.MediaItem.localFile.requestConcurrency: Number
+
+Allows controls how many images are downloaded at a time. Try lowering this if your wordpress server is giving 500 or 408 errors.
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    type: {
+      MediaItem: {
+        localFile: {
+          requestConcurrency: 50 // 100 by default
         },
       },
     },

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -21,6 +21,7 @@
     - [schema.typePrefix: String](#schematypeprefix-string)
     - [schema.timeout: Int](#schematimeout-int)
     - [schema.perPage: Int](#schemaperpage-int)
+    - [schema.requestConcurrency: Int](#schemarequestconcurrency-int)
   - [excludeFieldNames: Array](#excludefieldnames-array)
   - [html: Object](#html-object)
     - [html.useGatsbyImage: Boolean](#htmlusegatsbyimage-boolean)
@@ -374,6 +375,23 @@ Default is `100`.
 },
 ```
 
+### schema.requestConcurrency: Int
+
+The number of graphql requests to make per second.
+
+Default is `50`.
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    schema: {
+      requestConcurrency: 50,
+    },
+  },
+},
+```
+
 ## excludeFieldNames: Array
 
 A list of field names to globally exclude from the ingested schema.
@@ -647,6 +665,8 @@ Default is `15728640` which is 15Mb.
 
 Allows controls how many images are downloaded at a time. Try lowering this if your wordpress server is giving 500 or 408 errors.
 
+Default is `100`
+
 ```js
 {
   resolve: `gatsby-source-wordpress-experimental`,
@@ -654,7 +674,7 @@ Allows controls how many images are downloaded at a time. Try lowering this if y
     type: {
       MediaItem: {
         localFile: {
-          requestConcurrency: 50 // 100 by default
+          requestConcurrency: 50
         },
       },
     },

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -379,7 +379,7 @@ Default is `100`.
 
 The GraphQL request concurrency limit when sourcing data from WPGraphQL.
 
-Default is `10`.
+Default is `15`.
 
 ```js
 {

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -377,9 +377,9 @@ Default is `100`.
 
 ### schema.requestConcurrency: Int
 
-The number of graphql requests to make per second.
+The GraphQL request concurrency limit when sourcing data from WPGraphQL.
 
-Default is `50`.
+Default is `10`.
 
 ```js
 {
@@ -663,7 +663,7 @@ Default is `15728640` which is 15Mb.
 
 ### type.MediaItem.localFile.requestConcurrency: Number
 
-Allows controls how many images are downloaded at a time. Try lowering this if your wordpress server is giving 500 or 408 errors.
+Controls how many images are downloaded concurrently at any time. Try lowering this if your WordPress server is returning 500 or 408 errors during MediaItem file sourcing.
 
 Default is `100`
 

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -40,6 +40,7 @@ export interface IPluginOptions {
     typePrefix: string
     timeout: number // 30 seconds
     perPage: number
+    requestConcurrency?: number
   }
   excludeFieldNames: []
   html: {
@@ -61,6 +62,7 @@ export interface IPluginOptions {
       localFile?: {
         excludeByMimeTypes?: string[]
         maxFileSizeBytes?: number
+        requestConcurrency?: number
       }
     }
   }
@@ -103,6 +105,7 @@ const defaultPluginOptions: IPluginOptions = {
     typePrefix: `Wp`,
     timeout: 30 * 1000, // 30 seconds
     perPage: 100,
+    requestConcurrency: 50,
   },
   excludeFieldNames: [],
   html: {
@@ -158,6 +161,7 @@ const defaultPluginOptions: IPluginOptions = {
       localFile: {
         excludeByMimeTypes: [],
         maxFileSizeBytes: 15728640, // 15Mb
+        requestConcurrency: 100,
       },
       beforeChangeNode: async ({
         remoteNode,

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -105,7 +105,7 @@ const defaultPluginOptions: IPluginOptions = {
     typePrefix: `Wp`,
     timeout: 30 * 1000, // 30 seconds
     perPage: 100,
-    requestConcurrency: 50,
+    requestConcurrency: 10,
   },
   excludeFieldNames: [],
   html: {

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -105,7 +105,7 @@ const defaultPluginOptions: IPluginOptions = {
     typePrefix: `Wp`,
     timeout: 30 * 1000, // 30 seconds
     perPage: 100,
-    requestConcurrency: 10,
+    requestConcurrency: 15,
   },
   excludeFieldNames: [],
   html: {

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -155,6 +155,12 @@ export function pluginOptionsSchema({ Joi }) {
         .description(
           `The number of nodes to fetch per page during node sourcing.`
         ),
+      requestConcurrency: Joi.number()
+        .integer()
+        .default(50)
+        .description(
+          `Amount of content nodes to download per second. Try lowering this if wordpress server crashes on import`
+        ),
     }).description(
       `Options related to fetching and ingesting the remote schema.`
     ),
@@ -228,6 +234,12 @@ export function pluginOptionsSchema({ Joi }) {
             .default(15728640)
             .description(
               `Allows preventing the download of files that are above a certain file size (in bytes).`
+            ),
+          requestConcurrency: Joi.number()
+            .integer()
+            .default(100)
+            .description(
+              `Amount of images to download concurrently. Try lowering this if wordpress server crashes on import`
             ),
         }),
       }),

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -157,7 +157,7 @@ export function pluginOptionsSchema({ Joi }) {
         ),
       requestConcurrency: Joi.number()
         .integer()
-        .default(10)
+        .default(15)
         .description(
           `The number of concurrent GraphQL requests to make at any time during node sourcing. Try lowering this if WordPress server crashes on import`
         ),

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -157,9 +157,9 @@ export function pluginOptionsSchema({ Joi }) {
         ),
       requestConcurrency: Joi.number()
         .integer()
-        .default(50)
+        .default(10)
         .description(
-          `Amount of content nodes to download per second. Try lowering this if wordpress server crashes on import`
+          `The number of concurrent GraphQL requests to make at any time during node sourcing. Try lowering this if WordPress server crashes on import`
         ),
     }).description(
       `Options related to fetching and ingesting the remote schema.`

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -11,9 +11,7 @@ import store from "~/store"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
-  void
-> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -66,9 +64,10 @@ const invokeLeftoverPreviewCallback = ({
   status,
   context,
   error,
-}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
-  void
-> => {
+}) => async ([nodeId, callback]: [
+  string,
+  OnPageCreatedCallback
+]): Promise<void> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -11,7 +11,9 @@ import store from "~/store"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
+  void
+> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -64,10 +66,9 @@ const invokeLeftoverPreviewCallback = ({
   status,
   context,
   error,
-}) => async ([nodeId, callback]: [
-  string,
-  OnPageCreatedCallback
-]): Promise<void> => {
+}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
+  void
+> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -1,6 +1,7 @@
 import fs from "fs-extra"
 import path from "path"
 import url from "url"
+import { bold as b } from "chalk"
 
 import retry from "async-retry"
 
@@ -59,18 +60,40 @@ export const errorPanicker = ({
     return
   }
 
-  if (
-    errorString.includes(`Response code 4`) ||
-    errorString.includes(`Response code 500`) ||
-    errorString.includes(`Response code 511`) ||
-    errorString.includes(`Response code 508`) ||
-    errorString.includes(`Response code 505`) ||
-    errorString.includes(`Response code 501`)
-  ) {
+  if (errorString.includes(`Response code 4`)) {
     reporter.log(``)
     reporter.info(
       formatLogMessage(
         `Unrecoverable error ${sharedError}\n\nFailing the build to prevent deploying a broken site.`
+      )
+    )
+    reporter.panic(error)
+  } else if (errorString.includes(`Response code 5`)) {
+    reporter.log(``)
+    reporter.info(
+      formatLogMessage(
+        [
+          `Unrecoverable error ${sharedError}`,
+          `\nYour wordpress host appears to be overloaded by our requests for images`,
+          `\nIn ${b(`gatsby-config.js`)}, try lowering the ${b(
+            `requestConcurrency`
+          )} for MediaItems:`,
+          `\nplugins: [
+  {
+    resolve: 'gatsby-source-wordpress-experimental',
+    options: {
+      url: 'https://mysite.com/graphql',
+      type: {
+        MediaItem: {
+          localFile: {
+            requestConcurrency: 50
+          }
+        }
+      }
+    },
+  }
+]`,
+        ].join(`\n`)
       )
     )
     reporter.panic(error)

--- a/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -1,7 +1,7 @@
 import fs from "fs-extra"
 import path from "path"
 import url from "url"
-import { bold as b } from "chalk"
+import { bold } from "chalk"
 
 import retry from "async-retry"
 
@@ -75,7 +75,7 @@ export const errorPanicker = ({
         [
           `Unrecoverable error ${sharedError}`,
           `\nYour wordpress host appears to be overloaded by our requests for images`,
-          `\nIn ${b(`gatsby-config.js`)}, try lowering the ${b(
+          `\nIn ${bold(`gatsby-config.js`)}, try lowering the ${bold(
             `requestConcurrency`
           )} for MediaItems:`,
           `\nplugins: [
@@ -93,6 +93,7 @@ export const errorPanicker = ({
     },
   }
 ]`,
+          `\nnote that GATSBY_CONCURRENT_REQUEST environment variable has been retired for these options`,
         ].join(`\n`)
       )
     )

--- a/plugin/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
+++ b/plugin/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
@@ -120,7 +120,7 @@ export const getGatsbyNodeTypeNames = () => {
 export const runFnForEachNodeQuery = async (fn) => {
   const nodeQueries = getContentTypeQueryInfos()
 
-  const chunkSize = getPluginOptions()?.schema?.requestConcurrency || 10
+  const chunkSize = getPluginOptions()?.schema?.requestConcurrency || 15
   const chunkedQueries = chunk(nodeQueries, chunkSize)
 
   for (const queries of chunkedQueries) {

--- a/plugin/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
+++ b/plugin/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
@@ -4,7 +4,7 @@ import { formatLogMessage } from "~/utils/format-log-message"
 import { CREATED_NODE_IDS } from "~/constants"
 
 import store from "~/store"
-import { getGatsbyApi } from "~/utils/get-gatsby-api"
+import { getGatsbyApi, getPluginOptions } from "~/utils/get-gatsby-api"
 import chunk from "lodash/chunk"
 
 import {
@@ -120,7 +120,7 @@ export const getGatsbyNodeTypeNames = () => {
 export const runFnForEachNodeQuery = async (fn) => {
   const nodeQueries = getContentTypeQueryInfos()
 
-  const chunkSize = process.env.GATSBY_CONCURRENT_DOWNLOAD || 50
+  const chunkSize = getPluginOptions()?.schema?.requestConcurrency || 10
   const chunkedQueries = chunk(nodeQueries, chunkSize)
 
   for (const queries of chunkedQueries) {

--- a/plugin/src/utils/fetch-graphql.js
+++ b/plugin/src/utils/fetch-graphql.js
@@ -373,7 +373,7 @@ ${slackChannelSupportMessage}`
     try {
       const urlWithoutTrailingSlash = url.replace(/\/$/, ``)
 
-      const response = await getgetHttp(limit).post(
+      const response = await getHttp(limit).post(
         [urlWithoutTrailingSlash, `/graphql`].join(``),
         { query, variables },
         requestOptions

--- a/plugin/src/utils/fetch-graphql.js
+++ b/plugin/src/utils/fetch-graphql.js
@@ -1,16 +1,23 @@
 import prettier from "prettier"
 import axios from "axios"
 import rateLimit from "axios-rate-limit"
-import chalk from "chalk"
+import { bold } from "chalk"
 import { formatLogMessage } from "./format-log-message"
 import store from "~/store"
 import { getPluginOptions } from "./get-gatsby-api"
 import urlUtil from "url"
 import { CODES } from "./report"
 
-const http = rateLimit(axios.create(), {
-  maxRPS: process.env.GATSBY_CONCURRENT_DOWNLOAD || 50,
-})
+let http = null
+
+const getHttp = (limit = 50) => {
+  if (!http) {
+    http = rateLimit(axios.create(), {
+      maxRPS: limit,
+    })
+  }
+  return http
+}
 
 const handleErrorOptions = async ({
   variables,
@@ -181,7 +188,7 @@ const handleGraphQLErrors = async ({
               : ``
           } \n\t ${
             error.message
-          }  \n\n Error path: ${errorPath} \n\n If you haven't already, try adding ${chalk.bold(
+          }  \n\n Error path: ${errorPath} \n\n If you haven't already, try adding ${bold(
             `define( 'GRAPHQL_DEBUG', true );`
           )} to your wp-config.php for more detailed error messages.`
         )
@@ -200,13 +207,13 @@ const handleGraphQLErrors = async ({
   })
 }
 
-const ensureStatementsAreTrue = `${chalk.bold(
+const ensureStatementsAreTrue = `${bold(
   `Please ensure the following statements are true`
 )} \n  - your WordPress URL is correct in gatsby-config.js\n  - your server is responding to requests \n  - WPGraphQL and WPGatsby are installed in your WordPress backend`
 
 // @todo add a link to docs page for debugging
 const genericError = ({ url }) =>
-  `GraphQL request to ${chalk.bold(url)} failed.\n\n${ensureStatementsAreTrue}`
+  `GraphQL request to ${bold(url)} failed.\n\n${ensureStatementsAreTrue}`
 
 const slackChannelSupportMessage = `If you're still having issues, please visit https://www.wpgraphql.com/community-and-support/\nand follow the link to join the WPGraphQL Slack.\nThere are a lot of folks there in the #gatsby channel who are happy to help with debugging.`
 
@@ -243,6 +250,31 @@ const handleFetchErrors = async ({
           } seconds).\n\nEither your URL is wrong, you need to increase server resources, or you need to decrease the amount of resources each request takes.\n\nYou can configure how much resources each request takes by lowering your \`options.schema.perPage\` value from the default of 100 nodes per request.\nAlternatively you can increase the request timeout by setting a value in milliseconds to \`options.schema.timeout\`, the current setting is ${timeout}.\n\n${genericError(
             { url }
           )}`,
+          { useVerboseStyle: true }
+        ),
+      },
+    })
+  }
+  if (e.message.includes(`Request failed with status code 50`)) {
+    reporter.error(e)
+    reporter.panic({
+      id: CODES.WordPress500ishError,
+      context: {
+        sourceMessage: formatLogMessage(
+          [
+            `Your wordpress server at ${bold(url)} appears to be overloaded.`,
+            `\nYou might try reducing the ${bold(
+              `requestConcurrency`
+            )} for content:`,
+            `\n{
+  resolve: 'gatsby-source-wordpress-experimental',
+  options: {
+    schema: {
+      requestConcurrency: 25
+    }
+  },
+}`,
+          ],
           { useVerboseStyle: true }
         ),
       },
@@ -327,6 +359,7 @@ ${slackChannelSupportMessage}`
   const responseReturnedHtml = response?.headers[`content-type`].includes(
     `text/html;`
   )
+  const limit = pluginOptions?.schema?.requestConcurrency
 
   if (responseReturnedHtml && isFirstRequest) {
     const requestOptions = {
@@ -340,7 +373,7 @@ ${slackChannelSupportMessage}`
     try {
       const urlWithoutTrailingSlash = url.replace(/\/$/, ``)
 
-      const response = await http.post(
+      const response = await getgetHttp(limit).post(
         [urlWithoutTrailingSlash, `/graphql`].join(``),
         { query, variables },
         requestOptions
@@ -358,11 +391,11 @@ ${slackChannelSupportMessage}`
             sourceMessage: formatLogMessage(
               `${
                 errorContext ? `${errorContext}` : ``
-              }\n\nThe supplied url ${chalk.bold(
+              }\n\nThe supplied url ${bold(
                 urlWithoutTrailingSlash
-              )} is invalid,\nhowever ${chalk.bold(
+              )} is invalid,\nhowever ${bold(
                 urlWithoutTrailingSlash + `/graphql`
-              )} works!\n\nFor this plugin to consume the wp-graphql schema, you'll need to specify the full URL\n(${chalk.bold(
+              )} works!\n\nFor this plugin to consume the wp-graphql schema, you'll need to specify the full URL\n(${bold(
                 urlWithoutTrailingSlash + `/graphql`
               )}) in your gatsby-config.\n\nYou can learn more about configuring the source plugin URL here:\n${docsLink}\n\n`
             ),
@@ -393,7 +426,7 @@ ${slackChannelSupportMessage}`
           } \n\nReceived HTML as a response. Are you sure ${url} is the correct URL?\n\nIf that URL redirects to the correct URL via WordPress in the browser,\nor you've entered the wrong URL in settings,\nyou might receive this error.\nVisit that URL in your browser, and if it looks good, copy/paste it from your URL bar to your config.\n\n${ensureStatementsAreTrue}${
             copyHtmlResponseOnError
               ? `\n\nCopied HTML response to your clipboard.`
-              : `\n\n${chalk.bold(
+              : `\n\n${bold(
                   `Further debugging`
                 )}\nIf you still receive this error after following the steps above, this may be a problem with your WordPress instance.\nA plugin or theme may be adding additional output for some posts or pages.\nAdd the following plugin option to copy the html response to your clipboard for debugging.\nYou can paste the response into an html file to see what's being returned.\n
 {
@@ -478,6 +511,7 @@ const fetchGraphql = async ({
   forceReportCriticalErrors = false,
 }) => {
   const { helpers, pluginOptions } = store.getState().gatsbyApi
+  const limit = pluginOptions?.schema?.requestConcurrency
 
   const { url: pluginOptionsUrl } = pluginOptions
   let { reporter } = helpers
@@ -514,7 +548,11 @@ const fetchGraphql = async ({
       requestOptions.auth = htaccessCredentials
     }
 
-    response = await http.post(url, { query, variables }, requestOptions)
+    response = await getHttp(limit).post(
+      url,
+      { query, variables },
+      requestOptions
+    )
 
     if (response.data === ``) {
       throw new Error(`GraphQL request returned an empty string.`)

--- a/plugin/src/utils/fetch-graphql.js
+++ b/plugin/src/utils/fetch-graphql.js
@@ -274,6 +274,11 @@ const handleFetchErrors = async ({
     }
   },
 }`,
+            `\nnote that ${bold(
+              `GATSBY_CONCURRENT_REQUEST`
+            )} environment variable has been retired for this option and ${bold(
+              `schema.requestConcurrency`
+            )}`,
           ],
           { useVerboseStyle: true }
         ),

--- a/plugin/src/utils/report.js
+++ b/plugin/src/utils/report.js
@@ -5,6 +5,7 @@ export const CODES = {
   RequestDenied: `111004`,
   Authentication: `111005`,
   Timeout: `111006`,
+  WordPress500ishError: `111007`,
 
   /* GraphQL Errors */
   RemoteGraphQLError: `112001`,

--- a/plugin/src/utils/report.js
+++ b/plugin/src/utils/report.js
@@ -56,4 +56,9 @@ export const ERROR_MAP = {
     level: `ERROR`,
     category: `SYSTEM`,
   },
+  [CODES.WordPress500ishError]: {
+    text: (context) => context.sourceMessage,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
 }


### PR DESCRIPTION
this trades out the env variable for `requestConcurrency` for two different plugin options

## TODO:
- [x] plugin options validation
- [x] docs
- [ ] override using/fallback to env variable?
- [x] seperate `requestConcurrency` for `MediaItem`
- [x] seperate `requestConcurrency` for `schema`
- [x] better errors for 5xx requests that are usually caused by request overloads