### PR TITLE
fix: disable content update polling when refresh is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.3
 
 - Gatsby core recently removed cache-manager-fs-hash which this plugin was importing. Unfortunately this plugin didn't have it declared as a dependency. This is now fixed!
+
 ## 3.1.2
 
 - Inline html links which had query params were not being made into relative Gatsby paths. This release fixes that. Thanks @rburgst!

--- a/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -70,7 +70,10 @@ const refetcher = async (
  * so we can update Gatsby nodes when data changes
  */
 const startPollingForContentUpdates = (helpers, pluginOptions) => {
-  if (process.env.WP_DISABLE_POLLING) {
+  if (
+    process.env.WP_DISABLE_POLLING ||
+    process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+  ) {
     return
   }
 


### PR DESCRIPTION
This work is tied to https://github.com/gatsbyjs/wp-gatsby/pull/62

This is ready for review but not to be merged. Just doing some manual testing now.