### PR TITLE
Feat: support pinc builds and improve regular preview timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
+## Upcoming
+
+- Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.
+- When receiving preview data from the wrong url, it no longer fails the build and outputs a warning instead.
+
 ## 3.1.3
 
 - Gatsby core recently removed cache-manager-fs-hash which this plugin was importing. Unfortunately this plugin didn't have it declared as a dependency. This is now fixed!
+
 ## 3.1.2
 
 - Inline html links which had query params were not being made into relative Gatsby paths. This release fixes that. Thanks @rburgst!

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk"
 import urlUtil from "url"
 import fetchGraphql from "~/utils/fetch-graphql"
+import fs from "fs-extra"
 
 import store from "~/store"
 
@@ -184,4 +185,19 @@ export const sourcePreviews = async (
     previewParentId: webhookBody.parentId,
     isPreview: true,
   })
+}
+
+/**
+ * This function writes out the modified time to the public directory
+ * WPGatsby checks for this file to know wether or not the currently previewed node
+ * has been deployed yet.
+ */
+export async function writeNodeModifiedToPublicDirectory({
+  node,
+}: {
+  node: { databaseId: number; modified: string }
+}): Promise<void> {
+  const directory = process.cwd() + `/public/__wp-preview/${node.databaseId}/`
+  await fs.ensureDir(directory)
+  await fs.writeFile(directory + `modified`, node.modified)
 }

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -155,7 +155,7 @@ export const sourcePreviews = async (
       graphqlEndpoint: webhookBody.remoteUrl,
     })
 
-    reporter.panic(
+    reporter.warn(
       formatLogMessage(
         `Received preview data from a different remote URL than the one specified in plugin options. \n\n ${chalk.bold(
           `Remote URL:`
@@ -164,6 +164,8 @@ export const sourcePreviews = async (
         )} ${url}`
       )
     )
+
+    return
   }
 
   store.dispatch.previewStore.setInPreviewMode(true)

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -186,18 +186,3 @@ export const sourcePreviews = async (
     isPreview: true,
   })
 }
-
-/**
- * This function writes out the modified time to the public directory
- * WPGatsby checks for this file to know wether or not the currently previewed node
- * has been deployed yet.
- */
-export async function writeNodeModifiedToPublicDirectory({
-  node,
-}: {
-  node: { databaseId: number; modified: string }
-}): Promise<void> {
-  const directory = process.cwd() + `/public/__wp-preview/${node.databaseId}/`
-  await fs.ensureDir(directory)
-  await fs.writeFile(directory + `modified`, node.modified)
-}

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk"
 import urlUtil from "url"
 import fetchGraphql from "~/utils/fetch-graphql"
-import fs from "fs-extra"
 
 import store from "~/store"
 

--- a/plugin/src/steps/preview/on-create-page.ts
+++ b/plugin/src/steps/preview/on-create-page.ts
@@ -1,7 +1,7 @@
 import { formatLogMessage } from "~/utils/format-log-message"
 import store from "~/store"
 import { GatsbyHelpers } from "~/utils/gatsby-types"
-import { inPreviewMode } from "."
+import { inPreviewMode, writeNodeModifiedToPublicDirectory } from "."
 
 /**
  * during onCreatePage we want to figure out which node the page is dependant on
@@ -104,4 +104,9 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
   store.dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
     nodeId: nodeIdThatCreatedThisPage,
   })
+
+  // manual test pinc builds timing issue
+  // await new Promise((resolve) => setTimeout(resolve, 4000))
+
+  await writeNodeModifiedToPublicDirectory({ node: nodeThatCreatedThisPage })
 }

--- a/plugin/src/steps/preview/on-create-page.ts
+++ b/plugin/src/steps/preview/on-create-page.ts
@@ -94,6 +94,18 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
     return
   }
 
+  // We need to add the modified time to pageContext so we can read it in WP
+  // This way can tell when the updated page has been deployed
+  if (!page.context.__wpGatsbyNodeModified) {
+    const pageCopy = { ...page }
+    pageCopy.context.__wpGatsbyNodeModified = nodeThatCreatedThisPage.modified
+
+    const { deletePage, createPage } = helpers.actions
+
+    deletePage(page)
+    createPage(pageCopy)
+  }
+
   await nodePageCreatedCallback({
     passedNode: nodeThatCreatedThisPage,
     pageNode: page,
@@ -107,6 +119,4 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
 
   // manual test pinc builds timing issue
   // await new Promise((resolve) => setTimeout(resolve, 4000))
-
-  await writeNodeModifiedToPublicDirectory({ node: nodeThatCreatedThisPage })
 }

--- a/plugin/src/steps/preview/on-create-page.ts
+++ b/plugin/src/steps/preview/on-create-page.ts
@@ -1,7 +1,7 @@
 import { formatLogMessage } from "~/utils/format-log-message"
 import store from "~/store"
 import { GatsbyHelpers } from "~/utils/gatsby-types"
-import { inPreviewMode, writeNodeModifiedToPublicDirectory } from "."
+import { inPreviewMode } from "."
 
 /**
  * during onCreatePage we want to figure out which node the page is dependant on
@@ -116,7 +116,4 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
   store.dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
     nodeId: nodeIdThatCreatedThisPage,
   })
-
-  // manual test pinc builds timing issue
-  // await new Promise((resolve) => setTimeout(resolve, 4000))
 }


### PR DESCRIPTION
This is currently released as a canary `gatsby-source-wordpress-experimental@3.1.4--beta.3`

- Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.
- When receiving preview data from the wrong url, it no longer fails the build