### PR TITLE
Fix: update schema breaks preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 3.2.1
 
-- Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby does not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
+- Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
+- Because of the above issue, automatic schema updates during `gatsby develop` also failed to keep working. We now use the Gatsby refresh API to re-trigger node sourcing and schema customization in our develop watcher as this is a public API and will be more stable than Gatsby internals.
+- `ensurePluginRequirementsAreMet` is called once on a cold cache but never again on a warm cache. We now call this again when the schema changes on a warm cache.
 ## 3.2.0
 
 - Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.2.1
+
+- Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby does not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
 ## 3.2.0
 
 - Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
 - Because of the above issue, automatic schema updates during `gatsby develop` also failed to keep working. We now use the Gatsby refresh API to re-trigger node sourcing and schema customization in our develop watcher as this is a public API and will be more stable than Gatsby internals.
-- `ensurePluginRequirementsAreMet` is called once on a cold cache but never again on a warm cache. We now call this again when the schema changes on a warm cache.
+- `ensurePluginRequirementsAreMet` is called once on a cold cache but never again on a warm cache. We now call this again when the schema changes on a warm cache to make sure that if the schema changes because the remote plugin versions changed, we recheck to make sure they're still in-range.
 - The default value of `options.develop.nodeUpdateInterval` has been increased from `300` to `5000`. Due to the time it takes everything to work across Gatsby and WP, as well as the fact that content is rarely updated at the exact start of the interval, this change is barely perceptible but will ease up some strain on WP when many developers are working on the same site or when `gatsby develop` is running for hours at a time.
+
 ## 3.2.0
 
 - Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log
 
-## 3.2.1
+## 3.3.0
 
 - Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
 - Because of the above issue, automatic schema updates during `gatsby develop` also failed to keep working. We now use the Gatsby refresh API to re-trigger node sourcing and schema customization in our develop watcher as this is a public API and will be more stable than Gatsby internals.
 - `ensurePluginRequirementsAreMet` is called once on a cold cache but never again on a warm cache. We now call this again when the schema changes on a warm cache.
+- The default value of `options.develop.nodeUpdateInterval` has been increased from `300` to `5000`. Due to the time it takes everything to work across Gatsby and WP, as well as the fact that content is rarely updated at the exact start of the interval, this change is barely perceptible but will ease up some strain on WP when many developers are working on the same site or when `gatsby develop` is running for hours at a time.
 ## 3.2.0
 
 - Fixes a timing issue between PINC builds and WPGatsby. Also improves the timing of regular Preview. In this plugin all that's done is the preview node modified time is added to the pageContext of the page being previewed.

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -187,7 +187,7 @@ Options related to the `gatsby develop` process.
 
 Specifies in milliseconds how often Gatsby will ask WP if data has changed during development. If you want to see data update in near-realtime while you're developing, set this low. Your server may have trouble responding to too many requests over a long period of time and in that case, set this high. Setting it higher saves electricity too ⚡️🌲
 
-Default is `300`.
+Default is `5000`.
 
 ```js
 {

--- a/plugin/src/models/develop.ts
+++ b/plugin/src/models/develop.ts
@@ -1,5 +1,5 @@
 interface IDevelopState {
-  pauseRefreshPolling: boolean
+  refreshPollingIsPaused: boolean
 }
 
 interface IDevelopReducers {
@@ -14,7 +14,7 @@ interface IPreviewStore {
 
 const developStore: IPreviewStore = {
   state: {
-    pauseRefreshPolling: false,
+    refreshPollingIsPaused: false,
   },
 
   reducers: {
@@ -23,7 +23,7 @@ const developStore: IPreviewStore = {
         process.env.NODE_ENV === `development` &&
         !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
       ) {
-        state.pauseRefreshPolling = true
+        state.refreshPollingIsPaused = true
       }
 
       return state
@@ -33,7 +33,7 @@ const developStore: IPreviewStore = {
         process.env.NODE_ENV === `development` &&
         !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
       ) {
-        state.pauseRefreshPolling = false
+        state.refreshPollingIsPaused = false
       }
 
       return state

--- a/plugin/src/models/develop.ts
+++ b/plugin/src/models/develop.ts
@@ -1,0 +1,44 @@
+interface IDevelopState {
+  pauseRefreshPolling: boolean
+}
+
+interface IDevelopReducers {
+  pauseRefreshPolling: (state: IDevelopState) => IDevelopState
+  resumeRefreshPolling: (state: IDevelopState) => IDevelopState
+}
+
+interface IPreviewStore {
+  state: IDevelopState
+  reducers: IDevelopReducers
+}
+
+const developStore: IPreviewStore = {
+  state: {
+    pauseRefreshPolling: false,
+  },
+
+  reducers: {
+    pauseRefreshPolling(state) {
+      if (
+        process.env.NODE_ENV === `development` &&
+        !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+      ) {
+        state.pauseRefreshPolling = true
+      }
+
+      return state
+    },
+    resumeRefreshPolling(state) {
+      if (
+        process.env.NODE_ENV === `development` &&
+        !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+      ) {
+        state.pauseRefreshPolling = false
+      }
+
+      return state
+    },
+  } as IDevelopReducers,
+}
+
+export default developStore

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -84,7 +84,7 @@ const defaultPluginOptions: IPluginOptions = {
     disableCompatibilityCheck: false,
   },
   develop: {
-    nodeUpdateInterval: 300,
+    nodeUpdateInterval: 5000,
     hardCacheMediaFiles: false,
     hardCacheData: false,
   },

--- a/plugin/src/models/index.ts
+++ b/plugin/src/models/index.ts
@@ -4,6 +4,7 @@ import logger from "./logger"
 import imageNodes from "./image-nodes"
 import wpHooks from "./wp-hooks"
 import previewStore from "./preview"
+import develop from "./develop"
 
 export default {
   remoteSchema,
@@ -12,4 +13,5 @@ export default {
   imageNodes,
   wpHooks,
   previewStore,
+  develop,
 }

--- a/plugin/src/steps/check-plugin-requirements.js
+++ b/plugin/src/steps/check-plugin-requirements.js
@@ -254,10 +254,16 @@ ${data.generalSettings.url}/wp-admin/options-permalink.php.
   }
 }
 
-const ensurePluginRequirementsAreMet = async (helpers, _pluginOptions) => {
+const ensurePluginRequirementsAreMet = async (helpers) => {
   if (helpers.traceId === `refresh-createSchemaCustomization`) {
     return
   }
+
+  const activity = helpers.reporter.activityTimer(
+    formatLogMessage(`ensuring plugin requiremenst are met`)
+  )
+
+  activity.start()
 
   const {
     gatsbyApi: {
@@ -272,7 +278,12 @@ const ensurePluginRequirementsAreMet = async (helpers, _pluginOptions) => {
   // if we don't have a cached remote schema MD5, this is a cold build
   const isFirstBuild = !(await getPersistentCache({ key: MD5_CACHE_KEY }))
 
-  if (!schemaWasChanged && !isFirstBuild) {
+  if (
+    !schemaWasChanged &&
+    !isFirstBuild &&
+    helpers.traceId !== `schemaWasChanged`
+  ) {
+    activity.end()
     return
   }
 
@@ -287,6 +298,8 @@ const ensurePluginRequirementsAreMet = async (helpers, _pluginOptions) => {
       disableCompatibilityCheck,
     }),
   ])
+
+  activity.end()
 }
 
 export { ensurePluginRequirementsAreMet }

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -96,7 +96,7 @@ export function pluginOptionsSchema({ Joi }) {
     develop: Joi.object({
       nodeUpdateInterval: Joi.number()
         .integer()
-        .default(300)
+        .default(5000)
         .description(
           `Specifies in milliseconds how often Gatsby will ask WP if data has changed during development. If you want to see data update in near-realtime while you're developing, set this low. Your server may have trouble responding to too many requests over a long period of time and in that case, set this high. Setting it higher saves electricity too ⚡️🌲`
         ),

--- a/plugin/src/steps/ingest-remote-schema/diff-schemas.js
+++ b/plugin/src/steps/ingest-remote-schema/diff-schemas.js
@@ -133,6 +133,16 @@ Please consider addressing this issue by changing your WordPress settings or plu
     helpers.reporter.warn(
       formatLogMessage(`The remote schema has changed, updating local schema.`)
     )
+    if (
+      process.env.NODE_ENV === `development` &&
+      !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+    ) {
+      helpers.reporter.warn(
+        formatLogMessage(
+          `If the schema change includes a data change\nyou'll need to run \`gatsby clean && gatsby develop\` to see the data update.`
+        )
+      )
+    }
     helpers.reporter.info(
       formatLogMessage(`Cached schema md5: ${cachedSchemaMd5}`)
     )

--- a/plugin/src/steps/ingest-remote-schema/index.js
+++ b/plugin/src/steps/ingest-remote-schema/index.js
@@ -9,16 +9,7 @@ import { buildNodeQueries } from "./build-queries-from-introspection/build-node-
 import { cacheFetchedTypes } from "./cache-fetched-types"
 import { writeQueriesToDisk } from "./write-queries-to-disk"
 
-import store from "../../store"
-
 const ingestRemoteSchema = async (helpers, pluginOptions) => {
-  if (
-    helpers.traceId === `refresh-createSchemaCustomization` &&
-    !store.getState().remoteSchema.allowRefreshSchemaUpdate
-  ) {
-    return
-  }
-
   const activity = helpers.reporter.activityTimer(
     formatLogMessage(`ingest WPGraphQL schema`)
   )

--- a/plugin/src/steps/source-nodes/index.js
+++ b/plugin/src/steps/source-nodes/index.js
@@ -34,7 +34,12 @@ const sourceNodes = async (helpers, pluginOptions) => {
   const fetchEverything =
     foundUsableHardCachedData ||
     !lastCompletedSourceTime ||
-    (!webhookBody.refreshing && schemaWasChanged)
+    // don't refetch everything in development
+    ((process.env.NODE_ENV !== `development` ||
+      // unless we're in preview mode
+      process.env.ENABLE_GATSBY_REFRESH_ENDPOINT) &&
+      // and the schema was changed
+      schemaWasChanged)
 
   // If this is an uncached build,
   // or our initial build to fetch and cache everything didn't complete,

--- a/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -64,9 +64,9 @@ const refetcher = async (
   { reconnectionActivity = null, retryCount = 1 } = {}
 ) => {
   try {
-    const { pauseRefreshPolling } = store.getState().develop
+    const { refreshPollingIsPaused } = store.getState().develop
 
-    if (!pauseRefreshPolling) {
+    if (!refreshPollingIsPaused) {
       await checkForNodeUpdates(helpers)
     }
 

--- a/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -1,7 +1,62 @@
-import fetchAndApplyNodeUpdates from "./fetch-node-updates"
 import { formatLogMessage } from "~/utils/format-log-message"
 import store from "~/store"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
+import { contentPollingQuery } from "../../../utils/graphql-queries"
+import fetchGraphql from "../../../utils/fetch-graphql"
+import { LAST_COMPLETED_SOURCE_TIME } from "../../../constants"
+
+const previouslyFoundActionIds = new Set()
+
+/**
+ * This function checks wether there is atleast 1 WPGatsby action ready to be processed by Gatsby
+ * If there is, it calls the refresh webhook so that schema customization and source nodes run again.
+ */
+const checkForNodeUpdates = async ({ cache, emitter }) => {
+  // get the last sourced time
+  const since = await cache.get(LAST_COMPLETED_SOURCE_TIME)
+
+  // make a graphql request for any actions that have happened since
+  const {
+    data: {
+      actionMonitorActions: { nodes },
+    },
+  } = await fetchGraphql({
+    query: contentPollingQuery,
+    variables: {
+      since,
+    },
+    // throw fetch errors and graphql errors so we can auto recover in refetcher()
+    throwGqlErrors: true,
+    throwFetchErrors: true,
+  })
+
+  // a very simple cache to make sure we don't process the same action twice within
+  // the same `gatsby develop` process.
+  const newActions = nodes.filter(({ id }) => {
+    if (previouslyFoundActionIds.has(id)) {
+      return false
+    } else {
+      previouslyFoundActionIds.add(id)
+      return true
+    }
+  })
+
+  if (newActions.length) {
+    // if there's atleast 1 new action, pause polling,
+    // refresh Gatsby schema+nodes and continue on
+    store.dispatch.develop.pauseRefreshPolling()
+
+    emitter.emit(`WEBHOOK_RECEIVED`, {
+      webhookBody: {
+        since,
+        refreshing: true,
+      },
+    })
+  } else {
+    // set new last completed source time and move on
+    await cache.set(LAST_COMPLETED_SOURCE_TIME, Date.now())
+  }
+}
 
 const refetcher = async (
   msRefetchInterval,
@@ -9,11 +64,11 @@ const refetcher = async (
   { reconnectionActivity = null, retryCount = 1 } = {}
 ) => {
   try {
-    await fetchAndApplyNodeUpdates({
-      intervalRefetching: true,
-      throwFetchErrors: true,
-      throwGqlErrors: true,
-    })
+    const { pauseRefreshPolling } = store.getState().develop
+
+    if (!pauseRefreshPolling) {
+      await checkForNodeUpdates(helpers)
+    }
 
     if (reconnectionActivity) {
       reconnectionActivity.end()
@@ -69,7 +124,7 @@ const refetcher = async (
  * Starts constantly refetching the latest WordPress changes
  * so we can update Gatsby nodes when data changes
  */
-const startPollingForContentUpdates = (helpers, pluginOptions) => {
+const startPollingForContentUpdates = (helpers) => {
   if (
     process.env.WP_DISABLE_POLLING ||
     process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
@@ -77,14 +132,9 @@ const startPollingForContentUpdates = (helpers, pluginOptions) => {
     return
   }
 
-  const { verbose } = store.getState().gatsbyApi.pluginOptions
+  const { verbose, develop } = store.getState().gatsbyApi.pluginOptions
 
-  const msRefetchInterval =
-    pluginOptions &&
-    pluginOptions.develop &&
-    pluginOptions.develop.nodeUpdateInterval
-      ? pluginOptions.develop.nodeUpdateInterval
-      : 300
+  const msRefetchInterval = develop?.nodeUpdateInterval ?? 300
 
   if (verbose) {
     helpers.reporter.log(``)

--- a/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -134,7 +134,7 @@ const startPollingForContentUpdates = (helpers) => {
 
   const { verbose, develop } = store.getState().gatsbyApi.pluginOptions
 
-  const msRefetchInterval = develop?.nodeUpdateInterval ?? 300
+  const msRefetchInterval = develop.nodeUpdateInterval
 
   if (verbose) {
     helpers.reporter.log(``)

--- a/plugin/src/steps/source-nodes/update-nodes/fetch-node-updates.js
+++ b/plugin/src/steps/source-nodes/update-nodes/fetch-node-updates.js
@@ -31,9 +31,7 @@ const fetchAndApplyNodeUpdates = async ({
 
   const { cache, reporter } = helpers
 
-  let activity
-
-  activity = reporter.activityTimer(
+  const activity = reporter.activityTimer(
     formatLogMessage(`pull updates since last build`)
   )
   activity.start()

--- a/plugin/src/steps/source-nodes/update-nodes/fetch-node-updates.js
+++ b/plugin/src/steps/source-nodes/update-nodes/fetch-node-updates.js
@@ -24,7 +24,6 @@ export const touchValidNodes = async () => {
  */
 const fetchAndApplyNodeUpdates = async ({
   since,
-  intervalRefetching,
   throwFetchErrors = false,
   throwGqlErrors = false,
 }) => {
@@ -34,12 +33,10 @@ const fetchAndApplyNodeUpdates = async ({
 
   let activity
 
-  if (!intervalRefetching) {
-    activity = reporter.activityTimer(
-      formatLogMessage(`pull updates since last build`)
-    )
-    activity.start()
-  }
+  activity = reporter.activityTimer(
+    formatLogMessage(`pull updates since last build`)
+  )
+  activity.start()
 
   if (!since) {
     since = await cache.get(LAST_COMPLETED_SOURCE_TIME)
@@ -48,27 +45,15 @@ const fetchAndApplyNodeUpdates = async ({
   // Check with WPGQL to create, delete, or update cached WP nodes
   const { wpActions, didUpdate } = await fetchAndRunWpActions({
     since,
-    intervalRefetching,
     helpers,
     pluginOptions,
     throwFetchErrors,
     throwGqlErrors,
   })
 
-  if (
-    // if we're refetching, we only want to touch all nodes
-    // if something changed
-    didUpdate ||
-    // if this is a regular build, we want to touch all nodes
-    // so they don't get garbage collected
-    !intervalRefetching
-  ) {
-    await touchValidNodes()
-  }
+  await touchValidNodes()
 
-  if (!intervalRefetching) {
-    activity.end()
-  }
+  activity.end()
 
   return { wpActions, didUpdate }
 }

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/index.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/index.js
@@ -4,8 +4,6 @@ import wpActionUPDATE from "./update"
 import { LAST_COMPLETED_SOURCE_TIME } from "~/constants"
 import { paginatedWpNodeFetch } from "~/steps/source-nodes/fetch-nodes/fetch-nodes-paginated"
 
-import { updateSchema } from "./update"
-
 import fetchAndCreateNonNodeRootFields from "~/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields"
 import { setHardCachedNodes } from "~/utils/cache"
 
@@ -122,7 +120,6 @@ export const handleWpActions = async (api) => {
 export const fetchAndRunWpActions = async ({
   helpers,
   pluginOptions,
-  intervalRefetching,
   since,
   throwFetchErrors = false,
   throwGqlErrors = false,
@@ -139,23 +136,12 @@ export const fetchAndRunWpActions = async ({
 
   const didUpdate = !!wpActions.length
 
-  if (didUpdate && intervalRefetching) {
-    /**
-    if we're not interval refetching, we don't need to update the schema here
-    this is just for development.
-    In production, the schemas will be diffed on every build before it gets to this point. but when we're interval refetching, schema customization wont be running so we need to run it ourselves before updating 
-    `refresh: true` is added to clear the schema completely before rebuilding incase fields have been removed.
-     */
-    await updateSchema({ refresh: true })
-  }
-
   if (didUpdate) {
     for (const wpAction of wpActions) {
       // Create, update, and delete nodes
       await handleWpActions({
         helpers,
         pluginOptions,
-        intervalRefetching,
         wpAction,
       })
     }

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -45,21 +45,6 @@ const normalizeUri = ({ uri, id, singleName }) => {
   return uri
 }
 
-export const updateSchema = async (args = {}) => {
-  store.dispatch.remoteSchema.toggleAllowRefreshSchemaUpdate()
-
-  // re-run schema customization so this node type is added to the schema
-  await customizeSchema({
-    parentSpan: null,
-    deferNodeMutation: true,
-    refresh: false,
-    ...args,
-  })
-
-  store.dispatch.remoteSchema.toggleAllowRefreshSchemaUpdate()
-  store.dispatch.remoteSchema.setSchemaWasChanged(false)
-}
-
 export const fetchAndCreateSingleNode = async ({
   singleName,
   id,
@@ -299,11 +284,7 @@ export const createSingleNode = async ({
   return { additionalNodeIds, node: remoteNode }
 }
 
-const wpActionUPDATE = async ({
-  helpers,
-  wpAction,
-  // intervalRefetching,
-}) => {
+const wpActionUPDATE = async ({ helpers, wpAction }) => {
   const reportUpdate = ({ setAction } = {}) => {
     const actionType = setAction || wpAction.actionType
 

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -1,5 +1,3 @@
-import { customizeSchema } from "gatsby/dist/services/customize-schema"
-
 import fetchGraphql from "~/utils/fetch-graphql"
 import store from "~/store"
 import { formatLogMessage } from "~/utils/format-log-message"

--- a/plugin/src/utils/graphql-queries.js
+++ b/plugin/src/utils/graphql-queries.js
@@ -1,14 +1,25 @@
 import gql from "./gql"
 
 /**
+ * Used to check if there have been any updates at all. A single action is enough to trigger refreshing in gatsby develop
+ */
+export const contentPollingQuery = gql`
+  query GET_SINGLE_ACTION_MONITOR_ACTION($since: Float!) {
+    actionMonitorActions(where: { sinceTimestamp: $since }, first: 1) {
+      nodes {
+        id
+      }
+    }
+  }
+`
+
+/**
  * Used to fetch WP changes since a unix timestamp
  * so we can do incremental data fetches
  */
 export const actionMonitorQuery = gql`
   query GET_ACTION_MONITOR_ACTIONS($since: Float!, $after: String) {
-    # @todo add pagination in case there are more than 100 actions since the last build
     actionMonitorActions(
-      # @todo the orderby args aren't actually doing anything here. need to fix this
       where: { sinceTimestamp: $since, orderby: { field: DATE, order: DESC } }
       first: 100
       after: $after


### PR DESCRIPTION
Fixes #318 

In addition, I've made adjacent changes related to this issue to make sure our DX doesn't degrade by fixing this.

## 3.3.0

- Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.
- Because of the above issue, automatic schema updates during `gatsby develop` also failed to keep working. We now use the Gatsby refresh API to re-trigger node sourcing and schema customization in our develop watcher as this is a public API and will be more stable than Gatsby internals.
- `ensurePluginRequirementsAreMet` is called once on a cold cache but never again on a warm cache. We now call this again when the schema changes on a warm cache to make sure that if the schema changes because the remote plugin versions changed, we recheck to make sure they're still in-range.
- The default value of `options.develop.nodeUpdateInterval` has been increased from `300` to `5000`. Due to the time it takes everything to work across Gatsby and WP, as well as the fact that content is rarely updated at the exact start of the interval, this change is barely perceptible but will ease up some strain on WP when many developers are working on the same site or when `gatsby develop` is running for hours at a time.