### PR TITLE
Fix: preview draft posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Preview errors for brand new draft posts were not being passed back to Gatsby properly. This is now fixed :)
 - The full error message is now passed back to the Gatsby preview template instead of just the generic name of the step in which the error ocurred.
 - In order to make new post draft previews not cause 404 errors in Gatsby, a dummy page-data.json is generated before PREVIEW_SUCCESS is sent back to WPGatsby. Now WPGatsby will read this dummy file instead of getting a 404. This speeds up new post draft previews and eliminates a long trail of 404 errors in the Gatsby Preview instance logs.
+
 ## 3.3.0
 
 - Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Upcoming
+
+- Preview errors for brand new draft posts were not being passed back to Gatsby properly. This is now fixed :)
+- The full error message is now passed back to the Gatsby preview template instead of just the generic name of the step in which the error ocurred.
+- In order to make new post draft previews not cause 404 errors in Gatsby, a dummy page-data.json is generated before PREVIEW_SUCCESS is sent back to WPGatsby. Now WPGatsby will read this dummy file instead of getting a 404. This speeds up new post draft previews and eliminates a long trail of 404 errors in the Gatsby Preview instance logs.
 ## 3.3.0
 
 - Version 3.0.0 made an attempt to remove expensive schema diffing at the beginning of each preview or delta update. The strategy was that when a GraphQL query to WPGraphQL failed, it would try to re-run createSchemaCustomization internally to recover and rebuild our internal sourcing queries before trying to make the query again. Unfortunately this caused issues because more recent versions of Gatsby do not allow createSchemaCustomization to be called in this way. This version reverts to the earlier behaviour where the remote schema md5 is diffed on every build or preview.

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -11,9 +11,7 @@ import store from "~/store"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
-  void
-> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -66,9 +64,10 @@ const invokeLeftoverPreviewCallback = ({
   status,
   context,
   error,
-}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
-  void
-> => {
+}) => async ([nodeId, callback]: [
+  string,
+  OnPageCreatedCallback
+]): Promise<void> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -11,7 +11,9 @@ import store from "~/store"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
+  void
+> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -29,9 +31,11 @@ export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promi
 export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
   status,
   context,
+  error,
 }: {
   status: string
   context?: string
+  error?: Error
 }): Promise<void> => {
   const state = store.getState()
 
@@ -44,7 +48,7 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
   if (leftoverCallbacksExist) {
     await Promise.all(
       Object.entries(leftoverCallbacks).map(
-        invokeLeftoverPreviewCallback({ getNode, status, context })
+        invokeLeftoverPreviewCallback({ getNode, status, context, error })
       )
     )
 
@@ -57,18 +61,24 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
  * This callback is invoked to send WP the preview status. In this case the status
  * is that we couldn't find a page for the node being previewed
  */
-const invokeLeftoverPreviewCallback = ({ getNode, status, context }) => async ([
-  nodeId,
-  callback,
-]: [string, OnPageCreatedCallback]): Promise<void> => {
+const invokeLeftoverPreviewCallback = ({
+  getNode,
+  status,
+  context,
+  error,
+}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
+  void
+> => {
   const passedNode = getNode(nodeId)
 
   await callback({
     passedNode,
+    nodeId,
     // we pass null as the path because no page was created for this node.
     // if it had been, this callback would've been removed earlier in the process
     pageNode: { path: null },
     status,
     context,
+    error,
   })
 }

--- a/plugin/src/utils/report.js
+++ b/plugin/src/utils/report.js
@@ -9,6 +9,9 @@ export const CODES = {
   /* GraphQL Errors */
   RemoteGraphQLError: `112001`,
   MissingAppendedPath: `112002`,
+
+  /* CodeErrors */
+  SourcePluginCodeError: `112003`,
 }
 
 export const ERROR_MAP = {
@@ -46,5 +49,10 @@ export const ERROR_MAP = {
     text: (context) => context.sourceMessage,
     level: `ERROR`,
     category: `THIRD_PARTY`,
+  },
+  [CODES.SourcePluginCodeError]: {
+    text: (context) => context.sourceMessage,
+    level: `ERROR`,
+    category: `SYSTEM`,
   },
 }

--- a/plugin/src/utils/run-steps.js
+++ b/plugin/src/utils/run-steps.js
@@ -1,5 +1,6 @@
 import { formatLogMessage } from "~/utils/format-log-message"
 import { invokeAndCleanupLeftoverPreviewCallbacks } from "../steps/preview/cleanup"
+import { CODES } from "./report"
 
 const runSteps = async (steps, helpers, pluginOptions, apiName) => {
   for (const step of steps) {
@@ -40,15 +41,19 @@ const runSteps = async (steps, helpers, pluginOptions, apiName) => {
       await invokeAndCleanupLeftoverPreviewCallbacks({
         status: `GATSBY_PREVIEW_PROCESS_ERROR`,
         context: sharedError,
+        error: e,
       })
 
-      helpers.reporter.error(e)
-      helpers.reporter.panic(
-        formatLogMessage(
-          `\n\n\t${sharedError}\n\tSee above for more information.`,
-          { useVerboseStyle: true }
-        )
-      )
+      helpers.reporter.error(e.message)
+      helpers.reporter.panic({
+        id: CODES.SourcePluginCodeError,
+        context: {
+          sourceMessage: formatLogMessage(
+            `\n\n\t${sharedError}\n\tSee above for more information.`,
+            { useVerboseStyle: true }
+          ),
+        },
+      })
     }
   }
 }


### PR DESCRIPTION
This PR improves previews for new post drafts.

## Changelog

- Preview errors for brand new draft posts were not being passed back to Gatsby properly. This is now fixed :)
- The full error message is now passed back to the Gatsby preview template instead of just the generic name of the step in which the error ocurred.
- In order to make new post draft previews not cause 404 errors in Gatsby, a dummy page-data.json is generated before PREVIEW_SUCCESS is sent back to WPGatsby. Now WPGatsby will read this dummy file instead of getting a 404. This speeds up new post draft previews and eliminates a long trail of 404 errors in the Gatsby Preview instance logs.

closes #320