### PR TITLE
fix: resolve aliased paths properly with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",
     "babel-plugin-import-globals": "^2.0.0",
-    "babel-plugin-root-import": "^6.4.1",
     "babel-preset-gatsby": "^0.2.29",
     "babel-preset-gatsby-package": "^0.2.9",
     "cross-env": "^5.2.1",

--- a/plugin/babel.config.js
+++ b/plugin/babel.config.js
@@ -1,13 +1,6 @@
 module.exports = {
-  presets: [[`babel-preset-gatsby-package`]],
+  presets: [`babel-preset-gatsby-package`],
   plugins: [
-    [
-      `babel-plugin-root-import`,
-      {
-        rootPathSuffix: `./src/`,
-        rootPathPrefix: `~/`,
-      },
-    ],
     [
       `@babel/plugin-proposal-private-methods`,
       {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -52,7 +52,6 @@
     "@babel/plugin-proposal-private-methods": "^7.10.1",
     "babel-jest": "^25.1.0",
     "babel-plugin-import-globals": "^2.0.0",
-    "babel-plugin-root-import": "^6.4.1",
     "babel-preset-gatsby": "^0.2.29",
     "babel-preset-gatsby-package": "^0.5.3",
     "cross-env": "^5.2.1",

--- a/plugin/src/steps/preview/on-create-page.ts
+++ b/plugin/src/steps/preview/on-create-page.ts
@@ -1,7 +1,7 @@
 import { formatLogMessage } from "~/utils/format-log-message"
 import store from "~/store"
 import { GatsbyHelpers } from "~/utils/gatsby-types"
-import { inPreviewMode } from "."
+import { inPreviewMode } from "~/steps/preview"
 
 /**
  * during onCreatePage we want to figure out which node the page is dependant on

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./src",
     "paths": {
-      "~/*": ["src/*"]
-    }
-  }
+      "~/*": ["*"]
+    },
+    "lib": ["ESNext", "DOM"],
+    "target": "ES6",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./plugin/tsconfig.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,13 +5164,6 @@ babel-plugin-remove-graphql-queries@^2.11.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.11.0.tgz#0d90f7c3e66033eebccf69b5c2618f1239e89ff0"
   integrity sha512-JJiC1JdMubakyCAppYnFqdXqX1sNRIYomoRQ1tH2xzXHrsmhk3lRUSozsEGWxsL7r9D7zacuhi6fF4vukIyo0w==
 
-babel-plugin-root-import@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-root-import/-/babel-plugin-root-import-6.5.0.tgz#ac4016426b5d36c48127c73ad199fa72c9ff8817"
-  integrity sha512-PTD8fPl4v1kwn01u9d4rgRavDs5Z+jv4qa4/y6iYtoSgM4/xmjwMqo66j5A/BTZQEMA6OV5iFgyZ1PIhroJqqg==
-  dependencies:
-    slash "^3.0.0"
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
this helps with:

- moving the project into gatsby monorepo
- setting up baseline typescript support (need at least some basic config)
- getting imports working in vscode and other tools, and with inference engine

notes:
- this actually compiles with tsc! before, tsc would fail when checking these paths
- gatsby's babel config doesn't type check, so watch out! always try `tsc` from the `plugin` directly to confirm valid typescript types, unlike the usual build