### PR TITLE
fix: relative urls inside html content to include prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@ dist
 
 .DS_Store
 yarn-error.log
+
+# IDEs
 .vscode
+.idea
 
 node_modules
 public

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -48,6 +48,7 @@ export interface IPluginOptions {
     fallbackImageMaxWidth: number
     imageQuality: number
     createStaticFiles: boolean
+    prefixRelativeUrls: boolean
   }
   type: {
     [typename: string]: {
@@ -120,6 +121,9 @@ const defaultPluginOptions: IPluginOptions = {
     // Transforms anchor links, video src's, and audio src's (that point to wp-content files) into local file static links
     // Also fetches those files if they don't already exist
     createStaticFiles: true,
+    // If pathPrefix is used, relative links that don't start with the prefix will get prefixed.
+    // Example: <a href="/relative/url/"></a> will be <a href="/path-prefix/relative/url/">
+    prefixRelativeUrls: true,
   },
   type: {
     __all: {


### PR DESCRIPTION
Issue: #310 

So when using pathPrefix, relativeUrls inside html don't get prefixed. This doesn't make much sense, since I might want to create content in WordPress with relative URLs that don't use the prefix yet, so later I can change the prefix to whatever I want.

Where this comes in handy and was really necessary, is a multisite setup with multiple translations. 

What this fix does: When pathPrefix is used and the `pluginOption.prefixRelativeUrls` is active, the nodeStrings will be searched for elements, that start with `href=` and include a url that starts with `/`.

Excluded by the regex are urls that start with: `pathPrefix|/wp-content|/wp-admin|/wp-includes|//`

So we don't want prefix already prefixed URLs or URLs that start with a double `//`. 

The other branch that was branched from v1.7.9 can be found here since I need a v1.7.10: https://github.com/henrikwirth/gatsby-source-wordpress-experimental/tree/fix-relative-urls-in-html

