### PR TITLE
Feat: update the source plugin to work with WPGatsby v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 4.0.0
+
+### Breaking changes
+
+- Actions are no longer deduped when watching for WP changes. This is a breaking change because WPGatsby had to change in order to make this happen. So we need to change our compatibility API ranges to ensure regular functionality around this keeps working. If only WPGatsby was updated but not the source plugin, content updates would stop working. This makes it a breaking change even though for a user everything seems the same. Under the hood this is a huge improvement for the amount of resources the source plugin and WPGatsby are consuming and will result in less build failures.
+
 ## 3.3.1
 
 - Preview errors for brand new draft posts were not being passed back to Gatsby properly. This is now fixed :)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         # specify version updates here
         # this is for plugins installed via git or tar
         WPGRAPHQL_VERSION: v1.0
-        WPGATSBY_VERSION: v0.7.0
+        WPGATSBY_VERSION: v0.7.1
         WPGRAPHQL_ACF_VERSION: v0.3.1
         WPGRAPHQL_CPT_UI_VERSION: v1.1
         ACF_VERSION: 5.8.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         # specify version updates here
         # this is for plugins installed via git or tar
         WPGRAPHQL_VERSION: v1.0
-        WPGATSBY_VERSION: v0.6.0
+        WPGATSBY_VERSION: v0.7.0
         WPGRAPHQL_ACF_VERSION: v0.3.1
         WPGRAPHQL_CPT_UI_VERSION: v1.1
         ACF_VERSION: 5.8.7

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-wordpress-experimental",
   "description": "Source data from WPGraphQL in an efficient and scalable way.",
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
-  "version": "3.3.1",
+  "version": "4.0.0",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/issues"
   },

--- a/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/plugin/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -5,8 +5,6 @@ import { contentPollingQuery } from "../../../utils/graphql-queries"
 import fetchGraphql from "../../../utils/fetch-graphql"
 import { LAST_COMPLETED_SOURCE_TIME } from "../../../constants"
 
-const previouslyFoundActionIds = new Set()
-
 /**
  * This function checks wether there is atleast 1 WPGatsby action ready to be processed by Gatsby
  * If there is, it calls the refresh webhook so that schema customization and source nodes run again.
@@ -18,7 +16,7 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
   // make a graphql request for any actions that have happened since
   const {
     data: {
-      actionMonitorActions: { nodes },
+      actionMonitorActions: { nodes: newActions },
     },
   } = await fetchGraphql({
     query: contentPollingQuery,
@@ -28,17 +26,6 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
     // throw fetch errors and graphql errors so we can auto recover in refetcher()
     throwGqlErrors: true,
     throwFetchErrors: true,
-  })
-
-  // a very simple cache to make sure we don't process the same action twice within
-  // the same `gatsby develop` process.
-  const newActions = nodes.filter(({ id }) => {
-    if (previouslyFoundActionIds.has(id)) {
-      return false
-    } else {
-      previouslyFoundActionIds.add(id)
-      return true
-    }
   })
 
   if (newActions.length) {

--- a/plugin/src/supported-remote-plugin-versions.js
+++ b/plugin/src/supported-remote-plugin-versions.js
@@ -6,7 +6,7 @@ const supportedWpPluginVersions = {
     reason: null,
   },
   WPGatsby: {
-    version: `>=0.6.0 <0.7.0`,
+    version: `>=0.7.0 <0.8.0`,
     reason: null,
   },
 }

--- a/plugin/src/supported-remote-plugin-versions.js
+++ b/plugin/src/supported-remote-plugin-versions.js
@@ -6,7 +6,7 @@ const supportedWpPluginVersions = {
     reason: null,
   },
   WPGatsby: {
-    version: `>=0.7.0 <0.8.0`,
+    version: `>=0.7.1 <0.8.0`,
     reason: null,
   },
 }

--- a/test-site/__tests__/integration/schema/__snapshots__/integrity.test.js.snap
+++ b/test-site/__tests__/integration/schema/__snapshots__/integrity.test.js.snap
@@ -2701,6 +2701,7 @@ Array [
   Object {
     "fields": Array [
       "arePrettyPermalinksEnabled",
+      "isPreviewFrontendOnline",
     ],
     "name": "WpWPGatsby",
   },
@@ -2754,6 +2755,7 @@ Array [
   Object {
     "fields": Array [
       "actionType",
+      "content",
       "contentType",
       "databaseId",
       "date",
@@ -6388,6 +6390,7 @@ Array [
     "fields": Array [
       "arePrettyPermalinksEnabled",
       "gatsbyPreviewStatus",
+      "isPreviewFrontendOnline",
     ],
     "name": "WPGatsby",
   },

--- a/test-site/__tests__/integration/schema/__snapshots__/query-generation.test.js.snap
+++ b/test-site/__tests__/integration/schema/__snapshots__/query-generation.test.js.snap
@@ -2761,6 +2761,7 @@ exports[`[gatsby-source-wordpress-experimental] query generation [gatsby-source-
 
   wpGatsby {
     arePrettyPermalinksEnabled
+    isPreviewFrontendOnline
   }
 
   writingSettings {


### PR DESCRIPTION
### Breaking changes

- Actions are no longer deduped when watching for WP changes. This is a breaking change because WPGatsby had to change in order to make this happen. So we need to change our compatibility API ranges to ensure regular functionality around this keeps working. If only WPGatsby was updated but not the source plugin, content updates would stop working. This makes it a breaking change even though for a user everything seems the same in the case that they update both plugins. Under the hood this is a huge improvement for the amount of resources the source plugin and WPGatsby are consuming and will result in less build failures.

Related to https://github.com/gatsbyjs/wp-gatsby/pull/68