### PR TITLE
Fix: TypeError: Cannot read property 'includes' of undefined during createStaticFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+
+- Added an early return for when a MediaItem node has no mediaItemUrl in order to prevent errors when we later expect that this field exists. This can happen when the remote server returns a different type of node in place of a media item node or when the remote server has some corrupt data and this field is not returned.
+- When a MediaItem node could not be fetched while transforming images in html, we fetch the file directly and create a File node from it instead. These file nodes were not being cached as part of the hardCacheData api. They are now properly cached in this situation.
+- Changed the hueristic for when to clear the data hard cache from an md5 of the entire plugin options object to an md5 of the url option + the type options object. This means the hard cache will clear less frequently.
+
 ## 5.0.0
 
 ### New Features / Breaking Changes

--- a/plugin/src/steps/ingest-remote-schema/diff-schemas.js
+++ b/plugin/src/steps/ingest-remote-schema/diff-schemas.js
@@ -107,7 +107,10 @@ Please consider addressing this issue by changing your WordPress settings or plu
     key: pluginOptionsMD5Key,
   })
 
-  const pluginOptionsMD5 = createContentDigest(pluginOptions)
+  const pluginOptionsMD5 = createContentDigest({
+    url: pluginOptions.url,
+    type: pluginOptions.type,
+  })
 
   const shouldClearHardCache =
     schemaWasChanged || lastPluginOptionsMD5 !== pluginOptionsMD5

--- a/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -147,14 +147,17 @@ export const getFileNodeByMediaItemNode = async ({
 export const createRemoteMediaItemNode = async ({
   mediaItemNode,
   parentName,
+  skipExistingNode = false,
 }) => {
   const state = store.getState()
   const { helpers, pluginOptions } = state.gatsbyApi
 
-  const existingNode = await getFileNodeByMediaItemNode({
-    mediaItemNode,
-    helpers,
-  })
+  const existingNode = !skipExistingNode
+    ? await getFileNodeByMediaItemNode({
+        mediaItemNode,
+        helpers,
+      })
+    : null
 
   if (existingNode) {
     return existingNode

--- a/plugin/src/steps/source-nodes/create-nodes/process-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/process-node.js
@@ -19,6 +19,7 @@ import fetchReferencedMediaItemsAndCreateNodes, {
 } from "../fetch-nodes/fetch-referenced-media-items"
 import btoa from "btoa"
 import store from "~/store"
+import { createRemoteMediaItemNode } from "./create-remote-media-item-node"
 
 const getNodeEditLink = (node) => {
   const { protocol, hostname } = url.parse(node.link)
@@ -245,20 +246,32 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
       // we need to fetch it and create a file node for it with no
       // media item node.
       try {
-        const htaccessCredentials = pluginOptions.auth.htaccess
-
-        imageNode = await createRemoteFileNode({
-          url: htmlImgSrc,
-          parentNodeId: node.id,
-          auth: htaccessCredentials
-            ? {
-                htaccess_pass: htaccessCredentials?.password,
-                htaccess_user: htaccessCredentials?.username,
-              }
-            : null,
-          ...helpers,
-          createNode: helpers.actions.createNode,
+        imageNode = await createRemoteMediaItemNode({
+          skipExistingNode: true,
+          mediaItemNode: {
+            id: node.id,
+            mediaItemUrl: htmlImgSrc,
+            modifiedGmt: null,
+            mimeType: null,
+            title: null,
+            fileSize: null,
+          },
         })
+
+        // const htaccessCredentials = pluginOptions.auth.htaccess
+
+        // imageNode = await createRemoteFileNode({
+        //   url: htmlImgSrc,
+        //   parentNodeId: node.id,
+        //   auth: htaccessCredentials
+        //     ? {
+        //         htaccess_pass: htaccessCredentials?.password,
+        //         htaccess_user: htaccessCredentials?.username,
+        //       }
+        //     : null,
+        //   ...helpers,
+        //   createNode: helpers.actions.createNode,
+        // })
       } catch (e) {
         const sharedError = `when trying to fetch\n${htmlImgSrc}\nfrom ${
           node.__typename

--- a/plugin/src/steps/source-nodes/create-nodes/process-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/process-node.js
@@ -756,7 +756,7 @@ const replaceFileLinks = async ({
           helpers
         )
 
-        if (!relativeUrl || !mediaItemNode || !fileNode) {
+        if (!relativeUrl || !mediaItemNode?.mediaItemUrl || !fileNode) {
           return null
         }
 

--- a/plugin/src/steps/source-nodes/create-nodes/process-node.js
+++ b/plugin/src/steps/source-nodes/create-nodes/process-node.js
@@ -13,7 +13,7 @@ import { supportedExtensions } from "gatsby-transformer-sharp/supported-extensio
 import replaceAll from "replaceall"
 
 import { formatLogMessage } from "~/utils/format-log-message"
-import createRemoteFileNode from "./create-remote-file-node/index"
+
 import fetchReferencedMediaItemsAndCreateNodes, {
   stripImageSizesFromUrl,
 } from "../fetch-nodes/fetch-referenced-media-items"
@@ -257,21 +257,6 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
             fileSize: null,
           },
         })
-
-        // const htaccessCredentials = pluginOptions.auth.htaccess
-
-        // imageNode = await createRemoteFileNode({
-        //   url: htmlImgSrc,
-        //   parentNodeId: node.id,
-        //   auth: htaccessCredentials
-        //     ? {
-        //         htaccess_pass: htaccessCredentials?.password,
-        //         htaccess_user: htaccessCredentials?.username,
-        //       }
-        //     : null,
-        //   ...helpers,
-        //   createNode: helpers.actions.createNode,
-        // })
       } catch (e) {
         const sharedError = `when trying to fetch\n${htmlImgSrc}\nfrom ${
           node.__typename


### PR DESCRIPTION
### Bug Fixes

- Added an early return for when a MediaItem node has no mediaItemUrl in order to prevent errors when we later expect that this field exists. This can happen when the remote server returns a different type of node in place of a media item node or when the remote server has some corrupt data and this field is not returned.
- When a MediaItem node could not be fetched while transforming images in html, we fetch the file directly and create a File node from it instead. These file nodes were not being cached as part of the hardCacheData api. They are now properly cached in this situation.
- Changed the hueristic for when to clear the data hard cache from an md5 of the entire plugin options object to an md5 of the url option + the type options object. This means the hard cache will clear less frequently.