### PR TITLE
Update action monitor queries to order by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 
+.idea
 .DS_Store
 yarn-error.log
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# Upcoming
+
+- Updates Action Monitor queries to be ordered by modified date instead of created date
+
 ## 5.0.2
 
 This release adds support for WPGatsby v0.8.0 which adds a number of stability fixes and improvements. This is a non breaking release for the source plugin and a breaking change for WPGatsby but it's highly recommended to update to latest WPGatsby.

--- a/plugin/src/utils/graphql-queries.js
+++ b/plugin/src/utils/graphql-queries.js
@@ -5,7 +5,7 @@ import gql from "./gql"
  */
 export const contentPollingQuery = gql`
   query GET_SINGLE_ACTION_MONITOR_ACTION($since: Float!) {
-    actionMonitorActions(where: { sinceTimestamp: $since }, first: 1) {
+    actionMonitorActions(where: { sinceTimestamp: $since, orderby: { field: MODIFIED, order: DESC } }, first: 1) {
       nodes {
         id
       }
@@ -20,7 +20,7 @@ export const contentPollingQuery = gql`
 export const actionMonitorQuery = gql`
   query GET_ACTION_MONITOR_ACTIONS($since: Float!, $after: String) {
     actionMonitorActions(
-      where: { sinceTimestamp: $since, orderby: { field: DATE, order: DESC } }
+      where: { sinceTimestamp: $since, orderby: { field: MODIFIED, order: DESC } }
       first: 100
       after: $after
     ) {

--- a/plugin/src/utils/graphql-queries.js
+++ b/plugin/src/utils/graphql-queries.js
@@ -5,7 +5,13 @@ import gql from "./gql"
  */
 export const contentPollingQuery = gql`
   query GET_SINGLE_ACTION_MONITOR_ACTION($since: Float!) {
-    actionMonitorActions(where: { sinceTimestamp: $since, orderby: { field: MODIFIED, order: DESC } }, first: 1) {
+    actionMonitorActions(
+      where: {
+        sinceTimestamp: $since
+        orderby: { field: MODIFIED, order: DESC }
+      }
+      first: 1
+    ) {
       nodes {
         id
       }
@@ -20,7 +26,10 @@ export const contentPollingQuery = gql`
 export const actionMonitorQuery = gql`
   query GET_ACTION_MONITOR_ACTIONS($since: Float!, $after: String) {
     actionMonitorActions(
-      where: { sinceTimestamp: $since, orderby: { field: MODIFIED, order: DESC } }
+      where: {
+        sinceTimestamp: $since
+        orderby: { field: MODIFIED, order: DESC }
+      }
       first: 100
       after: $after
     ) {


### PR DESCRIPTION
This updates the action monitor queries to order by modified date instead of created date.