### PR TITLE
Fix: disginguish preview vs data update logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+- There was an errant log that was calling all incremental updates preview updates. It now distinguishes between previews and regular data updates.
+
 ## 6.0.0
 
 This release massively increases the performance of Gatsby Previews when more than one person is previewing or editing content at the same time. Previously when multiple users previewed simultaneously, only one of those users would see their preview or it would take a very long time for the others to see their previews. Now many users can preview concurrently. This was tested with a headless chrome puppeteer script. We found that 10 users making 100 previews over the course of a few minutes now have a 100% success rate. Previously 3 users making 30 previews would have a less than 30% success rate. This is a breaking change because WPGatsby has some changes which are required to make this work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 ### Bug Fixes
+
 - There was an errant log that was calling all incremental updates preview updates. It now distinguishes between previews and regular data updates.
 
 ## 6.0.0

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -99,7 +99,11 @@ export const fetchAndCreateSingleNode = async ({
   })
 
   reporter.info(
-    formatLogMessage(`Preview for ${singleName} ${node.id} was updated.`)
+    formatLogMessage(
+      `${isPreview ? `Preview` : `Data`} for ${singleName} ${
+        node.id
+      } was updated.`
+    )
   )
 
   return { node, additionalNodeIds }

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -98,13 +98,11 @@ export const fetchAndCreateSingleNode = async ({
     cachedNodeIds,
   })
 
-  reporter.info(
-    formatLogMessage(
-      `${isPreview ? `Preview` : `Data`} for ${singleName} ${
-        node.id
-      } was updated.`
+  if (isPreview) {
+    reporter.info(
+      formatLogMessage(`Preview for ${singleName} ${node.id} was updated.`)
     )
-  )
+  }
 
   return { node, additionalNodeIds }
 }


### PR DESCRIPTION
## Upcoming

### Bug Fixes
- There was an errant log that was calling all incremental updates preview updates. It now distinguishes between previews and regular data updates.