### PR TITLE
Fix: delete menu items when menus are deleted (and more)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+
+- GraphQL resolvers were previously attempting to lazy fetch nodes if the node isn't found in Gatsby. This is undesired behaviour because it will slow down resolvers considerably for any connections to deleted nodes. This behaviour was originally only intended for MediaItem nodes which could be set to be fetch lazily in resolvers. The fix here is to scope this behaviour only to MediaItem nodes and only when the MediaItem.lazyNodes option is enabled.
+- Due to a WPGraphQL bug where menu items can have a different id depending on which entry point they were fetched from, we had a problem of duplicated menu item nodes in some cases. This is temporarily fixed in this plugin until it's fixed upstream.
+- When deleting a menu in WP, all child menu items are deleted. We weren't previously accounting for this which meant there would be floater menu items in Gatsby which had no parent menu when a menu was deleted. We now clean up these menu item nodes automatically.
+
 ## 6.1.0
 
 ### Bug Fixes & internal changes

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -2,6 +2,7 @@ import { GatsbyNodeApiHelpers } from "~/utils/gatsby-types"
 import merge from "lodash/merge"
 import { createRemoteMediaItemNode } from "~/steps/source-nodes/create-nodes/create-remote-media-item-node"
 import { menuBeforeChangeNode } from "~/steps/source-nodes/before-change-node/menu"
+import { beforeChangeMenuItem } from "~/steps/source-nodes/before-change-node/menu-item"
 import { cloneDeep } from "lodash"
 
 export interface PluginOptionsPreset {
@@ -280,6 +281,7 @@ const defaultPluginOptions: IPluginOptions = {
       beforeChangeNode: menuBeforeChangeNode,
     },
     MenuItem: {
+      beforeChangeNode: beforeChangeMenuItem,
       /**
        * This was my previous attempt at fetching problematic menuItems
        * I temporarily solved this above, but I'm leaving this here as

--- a/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -54,6 +54,15 @@ export const buildGatsbyNodeObjectResolver = ({ field, fieldName }) => async (
 
   const queryInfo = getQueryInfoByTypeName(field.type.name)
 
+  if (
+    // only fetch/create nodes in resolvers for media items
+    queryInfo.nodesTypeName !== `MediaItem` ||
+    // and only when they have lazyNodes enabled
+    !queryInfo.settings.lazyNodes
+  ) {
+    return null
+  }
+
   // if this node doesn't exist, fetch it and create a node
   const { node } = await fetchAndCreateSingleNode({
     id: nodeField.id,

--- a/plugin/src/steps/source-nodes/before-change-node/menu-item.js
+++ b/plugin/src/steps/source-nodes/before-change-node/menu-item.js
@@ -1,0 +1,16 @@
+import atob from "atob"
+
+export function beforeChangeMenuItem(api) {
+  const { remoteNode } = api
+
+  const decodedId = atob(remoteNode.id)
+
+  // this MenuItem has an incorrect ID.
+  // this is a WPGQL bug that will be fixed soon.
+  if (decodedId.includes(`post`)) {
+    return {
+      // for now discard this node
+      cancelUpdate: true,
+    }
+  }
+}

--- a/plugin/src/steps/source-nodes/before-change-node/menu.js
+++ b/plugin/src/steps/source-nodes/before-change-node/menu.js
@@ -53,12 +53,12 @@ const fetchChildMenuItems = (api) => async () => {
 
   const remoteChildMenuItemNodes = Object.values(data)
 
-  remoteChildMenuItemNodes.forEach(
-    ({ id } = {}) => id && additionalNodeIds.push(id)
-  )
-
   await Promise.all(
     remoteChildMenuItemNodes.map(async (remoteMenuItemNode) => {
+      if (remoteMenuItemNode.id) {
+        additionalNodeIds.push(remoteMenuItemNode.id)
+      }
+
       // recursively fetch child menu items
       menuItemFetchQueue.add(
         fetchChildMenuItems({

--- a/plugin/src/steps/source-nodes/before-change-node/menu.js
+++ b/plugin/src/steps/source-nodes/before-change-node/menu.js
@@ -101,6 +101,7 @@ export const menuBeforeChangeNode = async (api) => {
   menuItemFetchQueue.add(fetchChildMenuItems({ ...api, additionalNodeIds }))
 
   await menuItemFetchQueue.onIdle()
+  await menuItemFetchQueue.onEmpty()
 
   return { additionalNodeIds }
 }

--- a/plugin/src/steps/source-nodes/before-change-node/menu.js
+++ b/plugin/src/steps/source-nodes/before-change-node/menu.js
@@ -129,6 +129,11 @@ export const menuBeforeChangeNode = async (api) => {
 
   const additionalNodeIds = []
 
+  // we delete all child menu items first to take care of a WPGQL bug
+  // where there are invalid menu items that are not properly attached to our menu
+  // because their ID's are incorrect.\
+  // @todo remove this once this is fixed in WPGQL
+  deleteMenuNodeChildMenuItems(api.remoteNode)
   menuItemFetchQueue.add(fetchChildMenuItems({ ...api, additionalNodeIds }))
 
   await menuItemFetchQueue.onIdle()


### PR DESCRIPTION
Originally this PR was supposed to just be for deleting menu items when their parent menu was deleted, but I uncovered a few bugs along the way that needed to be fixed for this to work properly:

- GraphQL resolvers were previously attempting to lazy fetch nodes if the node isn't found in Gatsby. This is undesired behaviour because it will slow down resolvers considerably for any connections to deleted nodes. This behaviour was originally only intended for MediaItem nodes which could be set to be fetch lazily in resolvers. The fix here is to scope this behaviour only to MediaItem nodes and only when the MediaItem.lazyNodes option is enabled.
- Due to a WPGraphQL bug where menu items can have a different id depending on which entry point they were fetched from, we had a problem of duplicated menu item nodes in some cases. This is temporarily fixed in this plugin until it's fixed upstream.
- When deleting a menu in WP, all child menu items are deleted. We weren't previously accounting for this which meant there would be floater menu items in Gatsby which had no parent menu when a menu was deleted. We now clean up these menu item nodes automatically.