### PR TITLE
Feat: preview debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Restored lazy nodes resolvers for all nodes in previews. Because of the default preview preset, removing lazy nodes in the last version from everything except media item nodes ended up breaking previews that previously relied on things working this way. So in preview mode lazy nodes in resolvers is restored.
 - In Previews when the schema changed all nodes were being refetched. This is only desireable when the code also changes, because previews have no way to automatically adapt to schema changes. Schema updates in previews no longer refetch all nodes.
 
+### New Features
+
+- Added a preview debug mode which outputs relevant information for debugging Previews.
+- Added a debug option to print the diff of the previous and next schema to the terminal output when the remote schema changes. This option is automatically enabled in preview debug mode.
+
 ## 6.1.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
-- Restored lazy nodes resolvers for all nodes in previews. Because of the default preview preset, removing lazy nodes in the last version from everything except media item nodes ended up breaking previews that previously relied on things working this way. So in preview mode 
+- Restored lazy nodes resolvers for all nodes in previews. Because of the default preview preset, removing lazy nodes in the last version from everything except media item nodes ended up breaking previews that previously relied on things working this way. So in preview mode lazy nodes in resolvers is restored.
+- In Previews when the schema changed all nodes were being refetched. This is only desireable when the code also changes, because previews have no way to automatically adapt to schema changes. Schema updates in previews no longer refetch all nodes.
 
 ## 6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Upcoming
+
+### Bug Fixes
+
+- Restored lazy nodes resolvers for all nodes in previews. Because of the default preview preset, removing lazy nodes in the last version from everything except media item nodes ended up breaking previews that previously relied on things working this way. So in preview mode 
+
 ## 6.1.1
 
 ### Bug Fixes

--- a/docs/features/preview.md
+++ b/docs/features/preview.md
@@ -74,7 +74,7 @@ The preset (as found in src/models/gatsby-api.ts) is:
 }
 ```
 
-## Debugging Previews
+## Debugging Previews in React
 
 Since a Previewed post might have a lot less data attached to it than what you're testing with during development, you might get errors in previews when that data is missing. You can debug your previews by running Gatsby in preview mode locally.
 
@@ -84,6 +84,10 @@ Since a Previewed post might have a lot less data attached to it than what you'r
 - In your WP instance's GatsbyJS settings, set your Preview instance URL to `https://your-ngrok-url.ngrok.io` and your Preview webhook to `https://your-ngrok-url.ngrok.io/__refresh`
 
 Now when you click the preview button in `wp-admin` it will use your local instance of Gatsby. You can inspect the preview template to see which Gatsby page is being loaded in the preview iframe and open it directly to do further debugging.
+
+## Debugging the build process of Previews
+
+If you enable the plugin option `options.debug.preview` by setting it to `true`, you will see additional logging through the Preview build process with information such as the contents of the webhook body that was sent to Gatsby, the preview node data, and the list of preview actions that were pulled from WordPress. See the [plugin options](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/plugin-options.md#debugpreview-object) documentation for more info.
 
 ## How Preview works behind the scenes
 

--- a/docs/features/preview.md
+++ b/docs/features/preview.md
@@ -87,7 +87,7 @@ Now when you click the preview button in `wp-admin` it will use your local insta
 
 ## Debugging the build process of Previews
 
-If you enable the plugin option `options.debug.preview` by setting it to `true`, you will see additional logging through the Preview build process with information such as the contents of the webhook body that was sent to Gatsby, the preview node data, and the list of preview actions that were pulled from WordPress. See the [plugin options](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/plugin-options.md#debugpreview-object) documentation for more info.
+If you enable the plugin option `options.debug.preview` by setting it to `true`, you will see additional logging through the Preview build process with information such as the contents of the webhook body that was sent to Gatsby, the preview node data, and the list of preview actions that were pulled from WordPress. See the [plugin options](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/plugin-options.md#debugpreview-boolean) documentation for more info.
 
 ## How Preview works behind the scenes
 

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -4,6 +4,7 @@
   - [url: String](#url-string)
   - [verbose: Boolean](#verbose-boolean)
   - [debug: Object](#debug-object)
+    - [debug.preview: Object](#debugpreview-object)
     - [debug.graphql: Object](#debuggraphql-object)
       - [debug.graphql.printIntrospectionDiff: Boolean](#debuggraphqlprintintrospectiondiff-boolean)
       - [debug.graphql.showQueryVarsOnError: Boolean](#debuggraphqlshowqueryvarsonerror-boolean)
@@ -80,6 +81,23 @@ An object which contains options related to debugging. See below for options.
   options: {
     debug: {
 
+    },
+  },
+},
+```
+
+### debug.preview: Object
+
+When set to true, this option will display additional information in the terminal output about the running preview process.
+
+Default is `false`.
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    debug: {
+      preview: true
     },
   },
 },

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -4,7 +4,7 @@
   - [url: String](#url-string)
   - [verbose: Boolean](#verbose-boolean)
   - [debug: Object](#debug-object)
-    - [debug.preview: Object](#debugpreview-object)
+    - [debug.preview: Boolean](#debugpreview-boolean)
     - [debug.graphql: Object](#debuggraphql-object)
       - [debug.graphql.printIntrospectionDiff: Boolean](#debuggraphqlprintintrospectiondiff-boolean)
       - [debug.graphql.showQueryVarsOnError: Boolean](#debuggraphqlshowqueryvarsonerror-boolean)
@@ -86,7 +86,7 @@ An object which contains options related to debugging. See below for options.
 },
 ```
 
-### debug.preview: Object
+### debug.preview: Boolean
 
 When set to true, this option will display additional information in the terminal output about the running preview process.
 

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -5,6 +5,7 @@
   - [verbose: Boolean](#verbose-boolean)
   - [debug: Object](#debug-object)
     - [debug.graphql: Object](#debuggraphql-object)
+      - [debug.graphql.printIntrospectionDiff: Boolean](#debuggraphqlprintintrospectiondiff-boolean)
       - [debug.graphql.showQueryVarsOnError: Boolean](#debuggraphqlshowqueryvarsonerror-boolean)
       - [debug.graphql.panicOnError: Boolean](#debuggraphqlpaniconerror-boolean)
       - [debug.graphql.onlyReportCriticalErrors: Boolean](#debuggraphqlonlyreportcriticalerrors-boolean)
@@ -95,6 +96,25 @@ An object which contains GraphQL debugging options. See below for options.
     debug: {
       graphql: {
 
+      },
+    },
+  },
+},
+```
+
+#### debug.graphql.printIntrospectionDiff: Boolean
+
+When this is set to true it will print out the diff between types in the previous and new schema when the schema changes. This is enabled by default when `debug.preview` is enabled.
+
+Default is `false`.
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    debug: {
+      graphql: {
+        printIntrospectionDiff: true,
       },
     },
   },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -23,6 +23,8 @@
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.3",
     "clipboardy": "^2.1.0",
+    "deep-object-diff": "^1.1.0",
+    "diff": "^5.0.0",
     "dumper.js": "^1.3.1",
     "execall": "^2.0.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -23,7 +23,6 @@
     "chalk": "^4.1.0",
     "cheerio": "^1.0.0-rc.3",
     "clipboardy": "^2.1.0",
-    "deep-object-diff": "^1.1.0",
     "diff": "^5.0.0",
     "dumper.js": "^1.3.1",
     "execall": "^2.0.0",

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -64,6 +64,7 @@ export interface IPluginOptions {
     }
     timeBuildSteps?: string[] | boolean
     disableCompatibilityCheck?: boolean
+    preview?: boolean
   }
   develop?: {
     nodeUpdateInterval?: number
@@ -135,6 +136,7 @@ const defaultPluginOptions: IPluginOptions = {
     },
     timeBuildSteps: false,
     disableCompatibilityCheck: false,
+    preview: false,
   },
   develop: {
     nodeUpdateInterval: 5000,

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -61,6 +61,7 @@ export interface IPluginOptions {
       copyNodeSourcingQueryAndExit?: boolean
       writeQueriesToDisk?: boolean
       copyHtmlResponseOnError?: boolean
+      printIntrospectionDiff?: boolean
     }
     timeBuildSteps?: string[] | boolean
     disableCompatibilityCheck?: boolean
@@ -137,6 +138,7 @@ const defaultPluginOptions: IPluginOptions = {
     timeBuildSteps: false,
     disableCompatibilityCheck: false,
     preview: false,
+    printIntrospectionDiff: false,
   },
   develop: {
     nodeUpdateInterval: 5000,

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -134,11 +134,11 @@ const defaultPluginOptions: IPluginOptions = {
       copyNodeSourcingQueryAndExit: false,
       writeQueriesToDisk: false,
       copyHtmlResponseOnError: false,
+      printIntrospectionDiff: false,
     },
     timeBuildSteps: false,
     disableCompatibilityCheck: false,
     preview: false,
-    printIntrospectionDiff: false,
   },
   develop: {
     nodeUpdateInterval: 5000,

--- a/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -2,6 +2,7 @@ import { buildTypeName } from "~/steps/create-schema-customization/helpers"
 import { fetchAndCreateSingleNode } from "~/steps/source-nodes/update-nodes/wp-actions/update"
 import { getQueryInfoByTypeName } from "~/steps/source-nodes/helpers"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
+import { inPreviewMode } from "~/steps/preview/index"
 
 export const transformListOfGatsbyNodes = ({ field, fieldName }) => {
   const typeName = buildTypeName(field.type.ofType.name)
@@ -56,9 +57,12 @@ export const buildGatsbyNodeObjectResolver = ({ field, fieldName }) => async (
 
   if (
     // only fetch/create nodes in resolvers for media items
-    queryInfo.nodesTypeName !== `MediaItem` ||
-    // and only when they have lazyNodes enabled
-    !queryInfo.settings.lazyNodes
+    (queryInfo.nodesTypeName !== `MediaItem` ||
+      // and only when they have lazyNodes enabled
+      !queryInfo.settings.lazyNodes) &&
+    // but if we're in preview mode we want to lazy fetch nodes
+    // because if nodes are limited we still want to lazy fetch connections
+    !inPreviewMode()
   ) {
     return null
   }

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -86,6 +86,11 @@ export function pluginOptionsSchema({ Joi }) {
           .description(
             `When true, all internal GraphQL queries generated during node sourcing will be written out to ./WordPress/GraphQL/[TypeName]/*.graphql for every type that is sourced. This is very useful for debugging GraphQL errors.`
           ),
+        printIntrospectionDiff: Joi.boolean()
+          .default(false)
+          .description(
+            `When true, changes to the remote schema will be printed in the terminal output.`
+          ),
       }),
     }).description(`Options related to debugging.`),
     production: Joi.object({

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -37,6 +37,11 @@ export function pluginOptionsSchema({ Joi }) {
       .default(true)
       .description(`Wether there will be verbose output in the terminal`),
     debug: Joi.object({
+      preview: Joi.boolean()
+        .default(false)
+        .description(
+          `When set to true, this option will display additional information in the terminal output about the running preview process.`
+        ),
       timeBuildSteps: Joi.boolean()
         .default(false)
         .description(

--- a/plugin/src/steps/ingest-remote-schema/diff-schemas.js
+++ b/plugin/src/steps/ingest-remote-schema/diff-schemas.js
@@ -135,10 +135,7 @@ Please consider addressing this issue by changing your WordPress settings or plu
     helpers.reporter.warn(
       formatLogMessage(`The remote schema has changed, updating local schema.`)
     )
-    if (
-      process.env.NODE_ENV === `development` &&
-      !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
-    ) {
+    if (process.env.NODE_ENV === `development`) {
       helpers.reporter.warn(
         formatLogMessage(
           `If the schema change includes a data change\nyou'll need to run \`gatsby clean && gatsby develop\` to see the data update.`

--- a/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -24,8 +24,6 @@ const introspectAndStoreRemoteSchema = async () => {
 
   if (!introspectionData || schemaWasChanged) {
     const { data } = await fetchGraphql({
-      // if we're printing the schema diff, we need to introspect
-      // using the graphql-js query so that buildClientSchema doesn't fail
       query: introspectionQuery,
     })
 

--- a/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -1,3 +1,6 @@
+import chalk from "chalk"
+import * as diff from "diff"
+import { uniqBy } from "lodash"
 import store from "~/store"
 import { setPersistentCache, getPersistentCache } from "~/utils/cache"
 import fetchGraphql from "~/utils/fetch-graphql"
@@ -13,10 +16,22 @@ const introspectAndStoreRemoteSchema = async () => {
     key: INTROSPECTION_CACHE_KEY,
   })
 
+  const printSchemaDiff =
+    pluginOptions?.debug?.schema?.printIntrospectionDiff ||
+    pluginOptions?.debug?.preview
+
+  let staleIntrospectionData
+
   if (!introspectionData || schemaWasChanged) {
     const { data } = await fetchGraphql({
+      // if we're printing the schema diff, we need to introspect
+      // using the graphql-js query so that buildClientSchema doesn't fail
       query: introspectionQuery,
     })
+
+    if (introspectionData) {
+      staleIntrospectionData = introspectionData
+    }
 
     introspectionData = data
 
@@ -24,6 +39,54 @@ const introspectAndStoreRemoteSchema = async () => {
     await setPersistentCache({
       key: INTROSPECTION_CACHE_KEY,
       value: introspectionData,
+    })
+  }
+
+  if (staleIntrospectionData && printSchemaDiff) {
+    console.log(`\nData changed in WordPress schema:`)
+    staleIntrospectionData.__schema.types.forEach((type) => {
+      const staleTypeJSON = JSON.stringify(type, null, 2)
+
+      const newType = introspectionData.__schema.types.find(
+        ({ name }) => name === type.name
+      )
+      const newTypeJSON = JSON.stringify(newType, null, 2)
+
+      if (staleTypeJSON === newTypeJSON) {
+        return
+      }
+
+      const typeDiff = uniqBy(diff.diffJson(type, newType), `value`)
+
+      if (typeDiff.length) {
+        console.log(`\nFound changes to the ${type.name} type\n`)
+        typeDiff.forEach((part) => {
+          if (part.added) {
+            console.log(
+              chalk.green(
+                chalk.bold(`Added:\n`) +
+                  part.value
+                    .trim()
+                    .split(`\n`)
+                    .map((line, index) => `+${index === 0 ? `\t` : ` `}${line}`)
+                    .join(`\n`)
+              )
+            )
+          } else if (part.removed) {
+            console.log(
+              chalk.red(
+                chalk.bold(`Removed:\n`) +
+                  part.value
+                    .trim()
+                    .split(`\n`)
+                    .map((line, index) => `-${index === 0 ? `\t` : ` `}${line}`)
+                    .join(`\n`)
+              )
+            )
+          }
+        })
+        console.log(`\n`)
+      }
     })
   }
 

--- a/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/plugin/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -17,7 +17,7 @@ const introspectAndStoreRemoteSchema = async () => {
   })
 
   const printSchemaDiff =
-    pluginOptions?.debug?.schema?.printIntrospectionDiff ||
+    pluginOptions?.debug?.graphql?.printIntrospectionDiff ||
     pluginOptions?.debug?.preview
 
   let staleIntrospectionData

--- a/plugin/src/steps/source-nodes/index.js
+++ b/plugin/src/steps/source-nodes/index.js
@@ -7,16 +7,9 @@ import store from "~/store"
 import fetchAndCreateNonNodeRootFields from "./create-nodes/fetch-and-create-non-node-root-fields"
 import { allowFileDownloaderProgressBarToClear } from "./create-nodes/create-remote-file-node/progress-bar-promise"
 import { sourcePreviews } from "~/steps/preview"
-import { formatLogMessage } from "../../utils/format-log-message"
-import { dump } from "dumper.js"
 
 const sourceNodes = async (helpers, pluginOptions) => {
   const { cache, webhookBody } = helpers
-
-  helpers.reporter.info(formatLogMessage(`Raw webhook:`))
-  dump(webhookBody)
-  // if (pluginOptions?.debug?.preview) {
-  // }
 
   // if this is a preview we want to process it and return early
   if (webhookBody.preview) {

--- a/plugin/src/steps/source-nodes/index.js
+++ b/plugin/src/steps/source-nodes/index.js
@@ -7,9 +7,16 @@ import store from "~/store"
 import fetchAndCreateNonNodeRootFields from "./create-nodes/fetch-and-create-non-node-root-fields"
 import { allowFileDownloaderProgressBarToClear } from "./create-nodes/create-remote-file-node/progress-bar-promise"
 import { sourcePreviews } from "~/steps/preview"
+import { formatLogMessage } from "../../utils/format-log-message"
+import { dump } from "dumper.js"
 
 const sourceNodes = async (helpers, pluginOptions) => {
   const { cache, webhookBody } = helpers
+
+  helpers.reporter.info(formatLogMessage(`Raw webhook:`))
+  dump(webhookBody)
+  // if (pluginOptions?.debug?.preview) {
+  // }
 
   // if this is a preview we want to process it and return early
   if (webhookBody.preview) {
@@ -43,9 +50,7 @@ const sourceNodes = async (helpers, pluginOptions) => {
     foundUsableHardCachedData ||
     !lastCompletedSourceTime ||
     // don't refetch everything in development
-    ((process.env.NODE_ENV !== `development` ||
-      // unless we're in preview mode
-      process.env.ENABLE_GATSBY_REFRESH_ENDPOINT) &&
+    (process.env.NODE_ENV !== `development` &&
       // and the schema was changed
       schemaWasChanged)
 

--- a/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/plugin/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -42,6 +42,7 @@ export const fetchAndCreateSingleNode = async ({
 
   const {
     helpers: { reporter },
+    pluginOptions,
   } = getGatsbyApi()
 
   if (!query) {
@@ -102,6 +103,11 @@ export const fetchAndCreateSingleNode = async ({
     reporter.info(
       formatLogMessage(`Preview for ${singleName} ${node.id} was updated.`)
     )
+
+    if (pluginOptions.debug.preview) {
+      reporter.info(formatLogMessage(`Raw remote node data:`))
+      dump(data)
+    }
   }
 
   return { node, additionalNodeIds }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,11 +7684,6 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deep-object-diff@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
-  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
-
 deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,6 +7684,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deep-object-diff@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
+  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
+
 deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
@@ -7909,6 +7914,11 @@ diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"


### PR DESCRIPTION
### Bug Fixes

- Restored lazy nodes resolvers for all nodes in previews. Because of the default preview preset, removing lazy nodes in the last version from everything except media item nodes ended up breaking previews that previously relied on things working this way. So in preview mode lazy nodes in resolvers is restored.
- In Previews when the schema changed all nodes were being refetched. This is only desireable when the code also changes, because previews have no way to automatically adapt to schema changes. Schema updates in previews no longer refetch all nodes.

### New Features

- Added a preview debug mode which outputs relevant information for debugging Previews.
- Added a debug option to print the diff of the previous and next schema to the terminal output when the remote schema changes. This option is automatically enabled in preview debug mode.

From the plugin options docs:

#### debug.graphql.printIntrospectionDiff: Boolean

When this is set to true it will print out the diff between types in the previous and new schema when the schema changes. This is enabled by default when `debug.preview` is enabled.

Default is `false`.

```js
{
  resolve: `gatsby-source-wordpress-experimental`,
  options: {
    debug: {
      graphql: {
        printIntrospectionDiff: true,
      },
    },
  },
},
```

and:

### debug.preview: Boolean

When set to true, this option will display additional information in the terminal output about the running preview process.

Default is `false`.

```js
{
  resolve: `gatsby-source-wordpress-experimental`,
  options: {
    debug: {
      preview: true
    },
  },
},
```

