### PR TITLE
Fix: account for stale previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Lowered `options.schema.previewRequestConcurrency` to 5.
+- Added a sinceTimestamp where arg to preview sourcing so that only previews created in the last 10 minutes are sourced.
 
 ## 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Upcoming
+
+### Changes
+
+- Lowered `options.schema.previewRequestConcurrency` to 5.
+
 ## 7.0.0
 
 ### Breaking Changes

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -435,7 +435,7 @@ Default is `15`.
 
 The GraphQL request concurrency limit when sourcing preview data from WPGraphQL.
 
-Default is `10`.
+Default is `5`.
 
 ```js
 {

--- a/plugin/src/models/gatsby-api.ts
+++ b/plugin/src/models/gatsby-api.ts
@@ -161,7 +161,7 @@ const defaultPluginOptions: IPluginOptions = {
     timeout: 30 * 1000, // 30 seconds
     perPage: 100,
     requestConcurrency: 15,
-    previewRequestConcurrency: 10,
+    previewRequestConcurrency: 5,
   },
   excludeFieldNames: [],
   html: {

--- a/plugin/src/steps/declare-plugin-options-schema.js
+++ b/plugin/src/steps/declare-plugin-options-schema.js
@@ -175,7 +175,7 @@ export function pluginOptionsSchema({ Joi }) {
         ),
       previewRequestConcurrency: Joi.number()
         .integer()
-        .default(10)
+        .default(5)
         .description(
           `The number of concurrent GraphQL requests to make at any time during preview sourcing. Try lowering this if your WordPress server crashes during previews. Normally this wont be needed and only comes into effect when multiple users are previewing simultaneously.`
         ),

--- a/plugin/src/steps/preview/index.ts
+++ b/plugin/src/steps/preview/index.ts
@@ -103,6 +103,10 @@ export const sourcePreviews = async (
             previewStream: true
             status: PRIVATE
             orderby: { field: MODIFIED, order: DESC }
+            sinceTimestamp: ${
+              // only source previews made in the last 10 minutes
+              Date.now() - 1000 * 60 * 10
+            }
           }
           first: 100
           after: $after


### PR DESCRIPTION
### Changes

- Lowered `options.schema.previewRequestConcurrency` to 5.
- Added a sinceTimestamp where arg to preview sourcing so that only previews created in the last 10 minutes are sourced.