### PR TITLE
Fix: media item lazynodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Upcoming
+
+### Bug fixes
+
+- Restored `type.MediaItem.lazyNodes` option which broke in a previous preview optimization release.
+
 ## 7.0.1
 
 ### Changes

--- a/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/plugin/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -55,11 +55,13 @@ export const buildGatsbyNodeObjectResolver = ({ field, fieldName }) => async (
 
   const queryInfo = getQueryInfoByTypeName(field.type.name)
 
+  const isLazyMediaItem =
+    queryInfo.typeInfo.nodesTypeName === `MediaItem` &&
+    queryInfo.settings.lazyNodes
+
   if (
-    // only fetch/create nodes in resolvers for media items
-    (queryInfo.nodesTypeName !== `MediaItem` ||
-      // and only when they have lazyNodes enabled
-      !queryInfo.settings.lazyNodes) &&
+    // only fetch/create nodes in resolvers for media items when they have lazyNodes enabled
+    !isLazyMediaItem &&
     // but if we're in preview mode we want to lazy fetch nodes
     // because if nodes are limited we still want to lazy fetch connections
     !inPreviewMode()

--- a/starters/gatsby-starter-wordpress-blog/package.json
+++ b/starters/gatsby-starter-wordpress-blog/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-offline": "^3.3.3",
     "gatsby-plugin-react-helmet": "^3.3.14",
     "gatsby-plugin-sharp": "^2.7.1",
-    "gatsby-source-wordpress-experimental": "^6.0.0",
+    "gatsby-source-wordpress-experimental": "^7.0.0",
     "gatsby-transformer-sharp": "^2.5.21",
     "html-react-parser": "^0.14.1",
     "lodash": "^4.17.20",

--- a/test-site/package.json
+++ b/test-site/package.json
@@ -28,7 +28,7 @@
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sharp": "^2.7.1",
     "gatsby-source-filesystem": "^2.3.37",
-    "gatsby-source-wordpress-experimental": "^6.0.0",
+    "gatsby-source-wordpress-experimental": "^7.0.0",
     "gatsby-transformer-sharp": "^2.5.21",
     "parse-path": "^4.0.1",
     "react": "^16.3.2",


### PR DESCRIPTION
### Bug fixes

- Restored `type.MediaItem.lazyNodes` option which broke in a previous preview optimization release.