### PR TITLE
Fix: broken plugin options schema

### DIFF
--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -1154,7 +1154,7 @@ An array of plugin options presets that are applied if the useIf function on eac
 **Default value**:
 
 ```js
-;[
+[
   {
     presetName: `PREVIEW_OPTIMIZATION`,
     useIf: (): boolean =>
@@ -1185,7 +1185,7 @@ An array of plugin options presets that are applied if the useIf function on eac
       },
     },
   },
-]
+];
 ```
 
 ### presets[].presetName

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -69,8 +69,6 @@ This is the only plugin option which is required for the plugin to work properly
 
 This should be the full url of your GraphQL endpoint.
 
-**Required:** yes
-
 **Field type**: `String`
 
 ```js
@@ -1149,14 +1147,14 @@ Amount of images to download concurrently. Try lowering this if wordpress server
 
 ## presets
 
-A preset of plugin options to be applied under some circumstance determined by the useIf function property.
+An array of plugin options presets that are applied if the useIf function on each returns true. The default includes an optimization for when in Gatsby Preview mode.
 
 **Field type**: `Array`
 
 **Default value**:
 
 ```js
-;[
+[
   {
     presetName: `PREVIEW_OPTIMIZATION`,
     useIf: (): boolean =>
@@ -1187,7 +1185,7 @@ A preset of plugin options to be applied under some circumstance determined by t
       },
     },
   },
-]
+];
 ```
 
 ### presets[].presetName

--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -1154,7 +1154,7 @@ An array of plugin options presets that are applied if the useIf function on eac
 **Default value**:
 
 ```js
-[
+;[
   {
     presetName: `PREVIEW_OPTIMIZATION`,
     useIf: (): boolean =>
@@ -1185,7 +1185,7 @@ An array of plugin options presets that are applied if the useIf function on eac
       },
     },
   },
-];
+]
 ```
 
 ### presets[].presetName

--- a/generate-plugin-options-docs.js
+++ b/generate-plugin-options-docs.js
@@ -4,7 +4,7 @@ const Handlebars = require(`handlebars`)
 const fs = require(`fs-extra`)
 const _ = require(`lodash`)
 const toc = require(`markdown-toc`)
-const prettierConfig = require(`./.prettierrc.js`)
+const prettierConfig = require(`./prettier.config.js`)
 
 const {
   pluginOptionsSchema,
@@ -163,13 +163,10 @@ async function generateMdFileFromSchemaDescription(description) {
     docs,
   })
 
-  const mdContentsFormatted = prettier.format(
-    mdContents,
-    {
-      parser: `markdown`,
-    },
-    prettierConfig
-  )
+  const mdContentsFormatted = prettier.format(mdContents, {
+    parser: `markdown`,
+    ...prettierConfig,
+  })
 
   await fs.writeFile(`./docs/plugin-options.md`, mdContentsFormatted)
 }

--- a/generate-plugin-options-docs.js
+++ b/generate-plugin-options-docs.js
@@ -175,6 +175,5 @@ async function generateMdFileFromSchemaDescription(description) {
 }
 
 const description = pluginOptionsSchema({ Joi }).describe()
-clipboardy.writeSync(JSON.stringify(description))
 
 generateMdFileFromSchemaDescription(description)

--- a/generate-plugin-options-docs.js
+++ b/generate-plugin-options-docs.js
@@ -4,6 +4,7 @@ const Handlebars = require(`handlebars`)
 const fs = require(`fs-extra`)
 const _ = require(`lodash`)
 const toc = require(`markdown-toc`)
+const prettierConfig = require(`./.prettierrc.js`)
 
 const {
   pluginOptionsSchema,
@@ -162,9 +163,13 @@ async function generateMdFileFromSchemaDescription(description) {
     docs,
   })
 
-  const mdContentsFormatted = prettier.format(mdContents, {
-    parser: `markdown`,
-  })
+  const mdContentsFormatted = prettier.format(
+    mdContents,
+    {
+      parser: `markdown`,
+    },
+    prettierConfig
+  )
 
   await fs.writeFile(`./docs/plugin-options.md`, mdContentsFormatted)
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-proposal-private-methods": "^7.10.1",
-    "@hapi/joi": "^17.1.1",
+    "@hapi/joi": "^15.1.1",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
     "babel-eslint": "^10.1.0",

--- a/plugin/src/steps/declare-plugin-options-schema.ts
+++ b/plugin/src/steps/declare-plugin-options-schema.ts
@@ -1,4 +1,5 @@
-const prettier = require(`prettier`)
+import prettier from "prettier"
+import { Root, SchemaLike } from "hapi__joi"
 
 const wrapOptions = (innerOptions) =>
   prettier
@@ -13,7 +14,7 @@ const wrapOptions = (innerOptions) =>
     .replace(`const something = `, ``)
     .replace(`;`, ``)
 
-export function pluginOptionsSchema({ Joi }) {
+export function pluginOptionsSchema({ Joi }: { Joi: Root }): SchemaLike {
   const getTypeOptions = () =>
     Joi.object({
       exclude: Joi.boolean()
@@ -21,15 +22,15 @@ export function pluginOptionsSchema({ Joi }) {
         .description(
           `Completely excludes a type from node sourcing and from the ingested schema.`
         )
-        .example(
-          wrapOptions(`
-            type: {
-              Page: {
-                exclude: true,
+        .meta({
+          example: wrapOptions(`
+              type: {
+                Page: {
+                  exclude: true,
+                },
               },
-            },
-          `)
-        ),
+            `),
+        }),
       limit: Joi.number()
         .integer()
         .allow(null)
@@ -42,33 +43,36 @@ export function pluginOptionsSchema({ Joi }) {
         .allow(null)
         .allow(false)
         .description(`Excludes fields on a type by field name.`)
-        .example(
-          wrapOptions(`
+        .meta({
+          example: wrapOptions(`
             type: {
               Page: {
                 excludeFieldNames: [\`dateGmt\`, \`parent\`],
               },
             },
-          `)
-        ),
+          `),
+        }),
       nodeInterface: Joi.boolean()
         .allow(null)
         .allow(false)
         .description(
           `Determines wether or not this type will be treated as an interface comprised entirely of other Gatsby node types.`
         )
-        .example(
-          wrapOptions(`
-            type: {
-              Page: {
-                nodeInterface: true
+        .meta({
+          example: wrapOptions(`
+              type: {
+                Page: {
+                  nodeInterface: true
+                }
               }
-            }
-          `)
-        ),
-      beforeChangeNode: Joi.function()
+            `),
+        }),
+      beforeChangeNode: Joi.any()
         .allow(null)
         .allow(false)
+        .meta({
+          trueType: `function`,
+        })
         .description(
           `A function which is invoked before a node is created, updated, or deleted. This is a hook in point to modify the node or perform side-effects related to it.`
         ),
@@ -80,102 +84,102 @@ export function pluginOptionsSchema({ Joi }) {
       .description(
         `Enables verbose logging in the terminal. Set to \`false\` to turn it off.`
       )
-      .example(
-        wrapOptions(`
-      verbose: true,`)
-      ),
+      .meta({
+        example: wrapOptions(`
+        verbose: true,`),
+      }),
     debug: Joi.object({
       preview: Joi.boolean()
         .default(false)
         .description(
           `When set to true, this option will display additional information in the terminal output about the running preview process.`
         )
-        .example(
-          wrapOptions(`
-          debug: {
-            preview: true
-          },
-        `)
-        ),
+        .meta({
+          example: wrapOptions(`
+            debug: {
+              preview: true
+            },
+          `),
+        }),
       timeBuildSteps: Joi.boolean()
         .default(false)
         .description(
           `When set to true, this option will display how long each internal step took during the build process.`
         )
-        .example(
-          wrapOptions(`
-            debug: {
-              timeBuildSteps: true,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              debug: {
+                timeBuildSteps: true,
+              },
+            `),
+        }),
       disableCompatibilityCheck: Joi.boolean()
         .default(false)
         .description(
           `This option disables the compatibility API check against the remote WPGraphQL and WPGatsby plugin versions. Note that it's highly recommended to not disable this setting. If you disable this setting you will receive no support until it's re-enabled. It's also highly likely that you'll run into major bugs without initially realizing that this was the cause.\n\nThis option should only be used for debugging.`
         )
-        .example(
-          wrapOptions(`
-            debug: {
-              disableCompatibilityCheck: true,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              debug: {
+                disableCompatibilityCheck: true,
+              },
+            `),
+        }),
       throwRefetchErrors: Joi.boolean()
         .default(false)
         .description(
           `When this is set to true, errors thrown while updating data in gatsby develop will fail the build process instead of automatically attempting to recover.`
         )
-        .example(
-          wrapOptions(`
-            debug: {
-              throwRefetchErrors: true
-            }
-        `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              debug: {
+                throwRefetchErrors: true
+              }
+          `),
+        }),
       graphql: Joi.object({
         showQueryVarsOnError: Joi.boolean()
           .default(false)
           .description(
             `When a GraphQL error is returned and the process exits, this plugin option determines wether or not to log out the query vars that were used in the query that returned GraphQL errors.`
           )
-          .example(
-            wrapOptions(`
-              debug: {
-                graphql: {
-                  showQueryVarsOnError: true,
+          .meta({
+            example: wrapOptions(`
+                debug: {
+                  graphql: {
+                    showQueryVarsOnError: true,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         showQueryOnError: Joi.boolean()
           .default(false)
           .description(
             `If enabled, GraphQL queries will be printed to the terminal output when the query returned errors.`
           )
-          .example(
-            wrapOptions(`
+          .meta({
+            example: wrapOptions(`
               debug: {
                 graphql: {
                   showQueryOnError: true
                 }
               }
-            `)
-          ),
+              `),
+          }),
         copyQueryOnError: Joi.boolean()
           .default(false)
           .description(
             `If enabled, GraphQL queries will be copied to your OS clipboard (if supported) when the query returned errors.`
           )
-          .example(
-            wrapOptions(`
-            debug: {
-              graphql: {
-                copyQueryOnError: true
+          .meta({
+            example: wrapOptions(`
+              debug: {
+                graphql: {
+                  copyQueryOnError: true
+                }
               }
-            }
-          `)
-          ),
+            `),
+          }),
         panicOnError: Joi.boolean()
           .default(false)
           .description(
@@ -183,121 +187,121 @@ export function pluginOptionsSchema({ Joi }) {
 
 Default is false because sometimes non-critical errors are returned alongside valid data.`
           )
-          .example(
-            wrapOptions(`
-              debug: {
-                graphql: {
-                  panicOnError: false,
+          .meta({
+            example: wrapOptions(`
+                debug: {
+                  graphql: {
+                    panicOnError: false,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         onlyReportCriticalErrors: Joi.boolean()
           .default(true)
           .description(
             `Determines wether or not to log non-critical errors. A non-critical error is any error which is returned alongside valid data. In previous versions of WPGraphQL this was very noisy because trying to access an entity that was private returned errors.`
           )
-          .example(
-            wrapOptions(`
-              debug: {
-                graphql: {
-                  onlyReportCriticalErrors: true,
+          .meta({
+            example: wrapOptions(`
+                debug: {
+                  graphql: {
+                    onlyReportCriticalErrors: true,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         copyNodeSourcingQueryAndExit: Joi.string()
           .allow(false)
           .default(false)
           .description(
             `When a type name from the remote schema is entered here, the node sourcing query will be copied to the clipboard, and the process will exit.`
           )
-          .example(
-            wrapOptions(`
+          .meta({
+            example: wrapOptions(`
               debug: {
                 graphql: {
                   copyNodeSourcingQueryAndExit: true
                 }
               }
-            `)
-          ),
+            `),
+          }),
         writeQueriesToDisk: Joi.boolean()
           .default(false)
           .description(
             `When true, all internal GraphQL queries generated during node sourcing will be written out to \`./WordPress/GraphQL/[TypeName]/*.graphql\` for every type that is sourced. This is very useful for debugging GraphQL errors.`
           )
-          .example(
-            wrapOptions(`
-              debug: {
-                graphql: {
-                  writeQueriesToDisk: true,
+          .meta({
+            example: wrapOptions(`
+                debug: {
+                  graphql: {
+                    writeQueriesToDisk: true,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         printIntrospectionDiff: Joi.boolean()
           .default(false)
           .description(
             `When this is set to true it will print out the diff between types in the previous and new schema when the schema changes. This is enabled by default when debug.preview is enabled.`
           )
-          .example(
-            wrapOptions(`
-              debug: {
-                graphql: {
-                  printIntrospectionDiff: true,
+          .meta({
+            example: wrapOptions(`
+                debug: {
+                  graphql: {
+                    printIntrospectionDiff: true,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
       })
         .description(
           `An object which contains GraphQL debugging options. See below for options.`
         )
-        .example(
-          wrapOptions(`
-            debug: {
-              graphql: {
-                // Add your options here :)
+        .meta({
+          example: wrapOptions(`
+              debug: {
+                graphql: {
+                  // Add your options here :)
+                },
               },
-            },
-          `)
-        ),
+            `),
+        }),
     })
       .description(
         `An object which contains options related to debugging. See below for options.`
       )
-      .example(
-        wrapOptions(`
-          debug: {
-            // Add your options here :)
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            debug: {
+              // Add your options here :)
+            },
+          `),
+      }),
     production: Joi.object({
       hardCacheMediaFiles: Joi.boolean()
         .default(false)
         .description(
           `This option is experimental. When set to true, media files will be hard-cached outside the Gatsby cache at ./.wordpress-cache/path/to/media/file.jpeg. This is useful for preventing media files from being re-downloaded when the Gatsby cache automatically clears. When using this option, be sure to gitignore the wordpress-cache directory in the root of your project.`
         )
-        .example(
-          wrapOptions(`
-            production: {
-              hardCacheMediaFiles: true
-            }
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              production: {
+                hardCacheMediaFiles: true
+              }
+            `),
+        }),
       allow404Images: Joi.boolean()
         .default(false)
         .description(
           `This option allows images url's that return a 404 to not fail production builds.`
         )
-        .example(
-          wrapOptions(`
-            production: {
-              allow404Images: true
-            }
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              production: {
+                allow404Images: true
+              }
+            `),
+        }),
     }),
     develop: Joi.object({
       nodeUpdateInterval: Joi.number()
@@ -306,25 +310,25 @@ Default is false because sometimes non-critical errors are returned alongside va
         .description(
           `Specifies in milliseconds how often Gatsby will ask WP if data has changed during development. If you want to see data update in near-realtime while you're developing, set this low. Your server may have trouble responding to too many requests over a long period of time and in that case, set this high. Setting it higher saves electricity too ⚡️🌲`
         )
-        .example(
-          wrapOptions(`
-            develop: {
-              nodeUpdateInterval: 300
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              develop: {
+                nodeUpdateInterval: 300
+              },
+            `),
+        }),
       hardCacheMediaFiles: Joi.boolean()
         .default(false)
         .description(
           `This option is experimental. When set to true, media files will be hard-cached outside the Gatsby cache at \`./.wordpress-cache/path/to/media/file.jpeg\`. This is useful for preventing media files from being re-downloaded when the Gatsby cache automatically clears. When using this option, be sure to gitignore the wordpress-cache directory in the root of your project.`
         )
-        .example(
-          wrapOptions(`
-            develop: {
-              hardCacheMediaFiles: true,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              develop: {
+                hardCacheMediaFiles: true,
+              },
+            `),
+        }),
       hardCacheData: Joi.boolean()
         .default(false)
         .description(
@@ -332,70 +336,70 @@ Default is false because sometimes non-critical errors are returned alongside va
 
 When using this option, be sure to gitignore the wordpress-cache directory in the root of your project.`
         )
-        .example(
-          wrapOptions(`
-            develop: {
-              hardCacheData: false,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              develop: {
+                hardCacheData: false,
+              },
+            `),
+        }),
     })
       .description(`Options related to the gatsby develop process.`)
-      .example(
-        wrapOptions(`
-          develop: {
-            // options related to \`gatsby develop\`
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            develop: {
+              // options related to \`gatsby develop\`
+            },
+          `),
+      }),
     auth: Joi.object({
       htaccess: Joi.object({
         username: Joi.string()
           .allow(null)
           .default(null)
           .description(`The username for your .htpassword protected site.`)
-          .example(
-            wrapOptions(`
-              auth: {
-                htaccess: {
-                  username: \`admin\`,
+          .meta({
+            example: wrapOptions(`
+                auth: {
+                  htaccess: {
+                    username: \`admin\`,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         password: Joi.string()
           .allow(null)
           .default(null)
           .description(`The password for your .htpassword protected site.`)
-          .example(
-            wrapOptions(`
-              auth: {
-                htaccess: {
-                  password: \`1234strong_password\`,
+          .meta({
+            example: wrapOptions(`
+                auth: {
+                  htaccess: {
+                    password: \`1234strong_password\`,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
       })
         .description(`Options related to htaccess authentication.`)
-        .example(
-          wrapOptions(`
-            auth: {
-              htaccess: {
-                // Add your options here :)
+        .meta({
+          example: wrapOptions(`
+              auth: {
+                htaccess: {
+                  // Add your options here :)
+                },
               },
-            },
-          `)
-        ),
+            `),
+        }),
     })
       .description(`Options related to authentication. See below for options.`)
-      .example(
-        wrapOptions(`
-          auth: {
-            // Add your options here :)
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            auth: {
+              // Add your options here :)
+            },
+          `),
+      }),
     schema: Joi.object({
       queryDepth: Joi.number()
         .integer()
@@ -404,13 +408,13 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `The maximum field depth the remote schema will be queried to.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              queryDepth: 15
-            }
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                queryDepth: 15
+              }
+            `),
+        }),
       circularQueryLimit: Joi.number()
         .integer()
         .positive()
@@ -418,99 +422,99 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `The maximum number times a type can appear as it's own descendant.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              circularQueryLimit: 5
-            }
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                circularQueryLimit: 5
+              }
+            `),
+        }),
       typePrefix: Joi.string()
         .default(`Wp`)
         .description(
           `The prefix for all ingested types from the remote schema. For example Post becomes WpPost.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              typePrefix: \`Wp\`,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                typePrefix: \`Wp\`,
+              },
+            `),
+        }),
       timeout: Joi.number()
         .integer()
         .default(30 * 1000)
         .description(
           `The amount of time in ms before GraphQL requests will time out.`
         )
-        .example(
-          wrapOptions(`
+        .meta({
+          example: wrapOptions(`
             schema: {
               timeout: 30000,
             },
-          `)
-        ),
+          `),
+        }),
       perPage: Joi.number()
         .integer()
         .default(100)
         .description(
           `The number of nodes to fetch per page during node sourcing.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              perPage: 100,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                perPage: 100,
+              },
+            `),
+        }),
       requestConcurrency: Joi.number()
         .integer()
         .default(15)
         .description(
           `The number of concurrent GraphQL requests to make at any time during node sourcing. Try lowering this if your WordPress server crashes while sourcing data.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              requestConcurrency: 50,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                requestConcurrency: 50,
+              },
+            `),
+        }),
       previewRequestConcurrency: Joi.number()
         .integer()
         .default(5)
         .description(
           `The number of concurrent GraphQL requests to make at any time during preview sourcing. Try lowering this if your WordPress server crashes during previews. Normally this wont be needed and only comes into effect when multiple users are previewing simultaneously.`
         )
-        .example(
-          wrapOptions(`
-            schema: {
-              previewRequestConcurrency: 50,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                previewRequestConcurrency: 50,
+              },
+            `),
+        }),
     })
       .description(
         `Options related to fetching and ingesting the remote schema.`
       )
-      .example(
-        wrapOptions(`
-          schema: {
-            // Add your options here :)
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            schema: {
+              // Add your options here :)
+            },
+          `),
+      }),
     excludeFieldNames: Joi.array()
       .items(Joi.string())
       .allow(null)
       .description(
         `A list of field names to globally exclude from the ingested schema.`
       )
-      .example(
-        wrapOptions(`
-          excludeFieldNames: [\`viewer\`],
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            excludeFieldNames: [\`viewer\`],
+          `),
+      }),
     html: Joi.object({
       useGatsbyImage: Joi.boolean()
         .default(true)
@@ -518,13 +522,13 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `Causes the source plugin to find/replace images in html with Gatsby images.`
         )
-        .example(
-          wrapOptions(`
-            html: {
-              useGatsbyImage: true,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              html: {
+                useGatsbyImage: true,
+              },
+            `),
+        }),
       imageMaxWidth: Joi.number()
         .integer()
         .allow(null)
@@ -532,13 +536,13 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `Adds a limit to the max width an image can be. If the image size selected in WP is smaller or the image file width is smaller than this those values will be used instead.`
         )
-        .example(
-          wrapOptions(`
-            html: {
-              imageMaxWidth: 1024,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              html: {
+                imageMaxWidth: 1024,
+              },
+            `),
+        }),
       fallbackImageMaxWidth: Joi.number()
         .integer()
         .allow(null)
@@ -546,13 +550,13 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `If a max width can't be inferred from html this value will be passed to Sharp. If the image is smaller than this, the image file's width will be used instead.`
         )
-        .example(
-          wrapOptions(`
-            html: {
-              fallbackImageMaxWidth: 800,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              html: {
+                fallbackImageMaxWidth: 800,
+              },
+            `),
+        }),
       imageQuality: Joi.number()
         .integer()
         .default(90)
@@ -560,49 +564,49 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `Determines the image quality that Sharp will use when generating inline html image thumbnails.`
         )
-        .example(
-          wrapOptions(`
-            html: {
-              imageQuality: 90,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              html: {
+                imageQuality: 90,
+              },
+            `),
+        }),
       createStaticFiles: Joi.boolean()
         .default(true)
         .allow(null)
         .description(
           `When this is true, any url's which are wrapped in "", '', or () and which contain /wp-content/uploads will be transformed into static files and the url's will be rewritten. This adds support for video, audio, and anchor tags which point at WP media item uploads as well as inline-html css like background-image: url().`
         )
-        .example(
-          wrapOptions(`
-            html: {
-              createStaticFiles: true,
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              html: {
+                createStaticFiles: true,
+              },
+            `),
+        }),
     })
       .description(`Options related to html field processing.`)
-      .example(
-        wrapOptions(`
-          html: {
-            // Add your options here :)
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            html: {
+              // Add your options here :)
+            },
+          `),
+      }),
     type: Joi.object({
       __all: getTypeOptions()
         .description(
           `A special type setting which is applied to all types in the ingested schema.`
         )
-        .example(
-          wrapOptions(`
-            type: {
-              __all: {
-                limit: 10,
+        .meta({
+          example: wrapOptions(`
+              type: {
+                __all: {
+                  limit: 10,
+                },
               },
-            },
-          `)
-        ),
+            `),
+        }),
       RootQuery: getTypeOptions()
         .append({
           excludeFieldNames: Joi.array()
@@ -615,28 +619,28 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .description(
           `A special type which is applied to any non-node root fields that are ingested and stored under the root \`wp\` field. It accepts the same options as other types.`
         )
-        .example(
-          wrapOptions(`
-            RootQuery: {
-              excludeFieldNames: [\`viewer\`]
-            },
-          `)
-        ),
+        .meta({
+          example: wrapOptions(`
+              RootQuery: {
+                excludeFieldNames: [\`viewer\`]
+              },
+            `),
+        }),
       MediaItem: Joi.object({
         lazyNodes: Joi.boolean()
           .default(false)
           .description(
             `Enables a different media item sourcing strategy. Instead of fetching Media Items that are referenced by other nodes, Media Items will be fetched in connection resolvers from other nodes. This may be desireable if you're not using all of the connected images in your WP instance. This is not currently recommended because it messes up cli output and can be slow due to query running concurrency.`
           )
-          .example(
-            wrapOptions(`
-              type: {
-                MediaItem: {
-                  lazyNodes: true,
+          .meta({
+            example: wrapOptions(`
+                type: {
+                  MediaItem: {
+                    lazyNodes: true,
+                  },
                 },
-              },
-            `)
-          ),
+              `),
+          }),
         localFile: Joi.object({
           excludeByMimeTypes: Joi.array()
             .items(Joi.string())
@@ -644,76 +648,76 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
             .description(
               `Allows preventing the download of files associated with MediaItem nodes by their mime types.`
             )
-            .example(
-              wrapOptions(`
-                type: {
-                  MediaItem: {
-                    localFile: {
-                      excludeByMimeTypes: [\`video/mp4\`]
+            .meta({
+              example: wrapOptions(`
+                  type: {
+                    MediaItem: {
+                      localFile: {
+                        excludeByMimeTypes: [\`video/mp4\`]
+                      },
                     },
                   },
-                },
-              `)
-            ),
+                `),
+            }),
           maxFileSizeBytes: Joi.number()
             .integer()
             .default(15728640)
             .description(
               `Allows preventing the download of files that are above a certain file size (in bytes). Default is 15mb.`
             )
-            .example(
-              wrapOptions(`
-                type: {
-                  MediaItem: {
-                    localFile: {
-                      maxFileSizeBytes: 10485760 // 10Mb
+            .meta({
+              example: wrapOptions(`
+                  type: {
+                    MediaItem: {
+                      localFile: {
+                        maxFileSizeBytes: 10485760 // 10Mb
+                      },
                     },
                   },
-                },
-              `)
-            ),
+                `),
+            }),
           requestConcurrency: Joi.number()
             .integer()
             .default(100)
             .description(
               `Amount of images to download concurrently. Try lowering this if wordpress server crashes on import`
             )
-            .example(
-              wrapOptions(`
-                type: {
-                  MediaItem: {
-                    localFile: {
-                      requestConcurrency: 50
+            .meta({
+              example: wrapOptions(`
+                  type: {
+                    MediaItem: {
+                      localFile: {
+                        requestConcurrency: 50
+                      },
                     },
                   },
-                },
-              `)
-            ),
+                `),
+            }),
         })
           .description(
             `Options related to File nodes that are attached to MediaItem nodes`
           )
-          .example(
-            wrapOptions(`
-        type: {
-          MediaItem: {
-            localFile: {
-              // Add your options here :)
+          .meta({
+            example: wrapOptions(`
+          type: {
+            MediaItem: {
+              localFile: {
+                // Add your options here :)
+              }
             }
-          }
-        }`)
-          ),
+          }`),
+          }),
       }),
     })
       .pattern(Joi.string(), getTypeOptions())
       .description(`Options related to specific types in the remote schema.`)
-      .example(
-        wrapOptions(`
-          type: {
-            // Add your options here :)
-          },
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            type: {
+              // Add your options here :)
+            },
+          `),
+      }),
   }).meta({
     // This is used in generating docs from this schema
     // so that we can prevent generating all options
@@ -729,11 +733,11 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
 
 This should be the full url of your GraphQL endpoint.`
       )
-      .example(
-        wrapOptions(`
-          url: \`https://yoursite.com/graphql\`
-        `)
-      ),
+      .meta({
+        example: wrapOptions(`
+            url: \`https://yoursite.com/graphql\`
+          `),
+      }),
   })
     .concat(joiSchema)
     .append({
@@ -742,88 +746,86 @@ This should be the full url of your GraphQL endpoint.`
           Joi.object({
             presetName: Joi.string()
               .description(`The name of the plugin options preset.`)
-              .example(
-                wrapOptions(`
-                  presets: [
-                    {
-                      presetName: \`DEVELOP\`
-                    }
-                  ]
-                `)
-              ),
-            useIf: Joi.function()
+              .meta({
+                example: wrapOptions(`
+                    presets: [
+                      {
+                        presetName: \`DEVELOP\`
+                      }
+                    ]
+                  `),
+              }),
+            useIf: Joi.any()
               .description(
                 `A function used to determine wether or not to apply this plugin options preset. It should return a boolean value. True will cause the preset to apply, false will disclude it.`
               )
               .default(`() => false`)
-              .example(
-                wrapOptions(`
-                  presets: [
-                    {
-                      useIf: () => process.env.NODE_ENV === \`development\`
-                    }
-                  ]
-                `)
-              ),
+              .meta({
+                trueType: `function`,
+                example: wrapOptions(`
+                    presets: [
+                      {
+                        useIf: () => process.env.NODE_ENV === \`development\`
+                      }
+                    ]
+                  `),
+              }),
             options: joiSchema
               .description(
                 `Any valid options except for \`url\` and \`presets\``
               )
-              .example(
-                wrapOptions(`
-                  presets: [
-                    {
-                      name: \`DEVELOP\`,
-                      useIf: () => process.env.NODE_ENV === \`development\`,
-                      options: {
-                        type: {
-                          __all: {
-                            limit: 1
+              .meta({
+                example: wrapOptions(`
+                    presets: [
+                      {
+                        name: \`DEVELOP\`,
+                        useIf: () => process.env.NODE_ENV === \`development\`,
+                        options: {
+                          type: {
+                            __all: {
+                              limit: 1
+                            }
                           }
                         }
                       }
-                    }
-                  ]
-                `)
-              ),
+                    ]
+                  `),
+              }),
           })
         )
+        .meta({
+          default: `[{
+            presetName: \`PREVIEW_OPTIMIZATION\`,
+            useIf: (): boolean => process.env.NODE_ENV === \`development\` &&
+            !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT || process.env.RUNNER_TYPE === \`PREVIEW\`,
+            options: {
+              html: {
+                useGatsbyImage: false,
+                createStaticFiles: false,
+              },
+              type: {
+                __all: {
+                  limit: 50,
+                },
+                Comment: {
+                  limit: 0,
+                },
+                Menu: {
+                  limit: null,
+                },
+                MenuItem: {
+                  limit: null,
+                },
+                User: {
+                  limit: null,
+                },
+              },
+            },
+          }]`,
+        })
         .description(
           `An array of plugin options presets that are applied if the useIf function on each returns true. The default includes an optimization for when in Gatsby Preview mode.`
         )
-        .default(
-          `[{
-  presetName: \`PREVIEW_OPTIMIZATION\`,
-  useIf: (): boolean => process.env.NODE_ENV === \`development\` &&
-  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT || process.env.RUNNER_TYPE === \`PREVIEW\`,
-  options: {
-    html: {
-      useGatsbyImage: false,
-      createStaticFiles: false,
-    },
-    type: {
-      __all: {
-        limit: 50,
-      },
-      Comment: {
-        limit: 0,
-      },
-      Menu: {
-        limit: null,
-      },
-      MenuItem: {
-        limit: null,
-      },
-      User: {
-        limit: null,
-      },
-    },
-  },
-}]`
-        )
-        .allow(null)
-        .description(
-          `A preset of plugin options to be applied under some circumstance determined by the useIf function property.`
-        ),
+        .allow(null),
     })
 }

--- a/plugin/src/steps/index.ts
+++ b/plugin/src/steps/index.ts
@@ -10,8 +10,6 @@ export { checkIfSchemaHasChanged } from "~/steps/ingest-remote-schema/diff-schem
 export { setErrorMap } from "~/steps/set-error-map"
 export { tempPreventMultipleInstances } from "~/steps/temp-prevent-multiple-instances"
 
-export { setPreviewState } from "~/steps/preview/index"
-
 export { onPreExtractQueriesInvokeLeftoverPreviewCallbacks } from "./preview/cleanup"
 
 export {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  endOfLine: "lf",
+  endOfLine: `lf`,
   semi: false,
   singleQuote: false,
   tabWidth: 2,
-  trailingComma: "es5",
+  trailingComma: `es5`,
 }


### PR DESCRIPTION
Well this was a hard one to figure out. Gatsby is using the deprecated version of Joi for which there are no docs. I had changed out plugin options schema to work with the latest joi version (not realizing Gatsby isn't using this) so I could generate our plugin options.. well this resulted in Gatsby swallowing the joi error somehow and the build crashing on something completely unrelated... I finally figured out what was causing it by trial and error (it was a default value in the joi schema that was a string where the actual field is not a string and latest joi allows examples that are strings where the deprecated Gatsby version only allows examples that are of the type of the field...