### PR TITLE
Docs: Add File.publicURL documentation

### DIFF
--- a/docs/features/media-item-processing.md
+++ b/docs/features/media-item-processing.md
@@ -62,15 +62,15 @@ You can install it in your project with `npm install gatsby-source-filesystem` o
 
 ```js
 module.exports = {
-    plugins: [
-        {
-        resolve: `gatsby-source-filesystem`,
-        options: {
-            name: `assets`,
-            path: `${__dirname}/content/assets`, // this needs to include a path with atleast 1 file
-          },
-        }
-    ],
+  plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `assets`,
+        path: `${__dirname}/content/assets`, // this needs to include a path with atleast 1 file
+      },
+    },
+  ],
 }
 ```
 

--- a/docs/features/media-item-processing.md
+++ b/docs/features/media-item-processing.md
@@ -52,3 +52,43 @@ Note that if you make a GraphQL request for any media item in Gatsby, it will st
 If you don't want this to happen you will have to make sure you don't query for those fields.
 
 :point_left: [Back to Features](./index.md)
+
+## Referencing static file public URL's
+
+If you want to use image/file url's directly instead of (or in addition) to using Gatsby Image, you can query for the `WpMediaItem.localFile.publicURL` field in GraphQL.
+However, for this field to be available you'll need to first install and configure `gatsby-source-filesystem` and point it at atleast 1 local file.
+
+You can install it in your project with `npm install gatsby-source-filesystem` or `yarn add gatsby-source-filesystem`. Once you do that you can add it to your `gatsby-config.js` like this:
+
+```js
+module.exports = {
+    plugins: [
+        {
+        resolve: `gatsby-source-filesystem`,
+        options: {
+            name: `assets`,
+            path: `${__dirname}/content/assets`, // this needs to include a path with atleast 1 file
+          },
+        }
+    ],
+}
+```
+
+Now when you run `gatsby develop`, you should be able to query for the public URL of any local file node in WP.
+This is mostly useful for when you need a direct file link to a PDF or other asset that you want your users to be able to download.
+
+```graphql
+query {
+  allWpPost {
+    nodes {
+      featuredImage {
+        node {
+          localFile {
+            publicURL
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -12,7 +12,9 @@ import { NodePluginArgs } from "gatsby"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
+  void
+> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -71,10 +73,9 @@ const invokeLeftoverPreviewCallback = ({
   context?: string
   error?: Error
   getNode: NodePluginArgs["getNode"]
-}) => async ([nodeId, callback]: [
-  string,
-  OnPageCreatedCallback
-]): Promise<void> => {
+}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
+  void
+> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/starters/gatsby-starter-wordpress-blog/gatsby-config.js
+++ b/starters/gatsby-starter-wordpress-blog/gatsby-config.js
@@ -58,6 +58,23 @@ module.exports = {
     `gatsby-plugin-react-helmet`,
 
     /**
+     * We're including this plugin because it allows us to query for File.publicURL
+     * so that we can query the public url of static files in GraphQL.
+     * This is mostly useful for PDF's and other files that you want users to be
+     * able to click and download.
+     *
+     * See https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/?=gatsby-source-filesystem
+     *
+     */
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `assets`,
+        path: `${__dirname}/content/assets`,
+      },
+    },
+
+    /**
      * this (optional) plugin enables Progressive Web App + Offline functionality
      * To learn more, visit: https://gatsby.dev/offline
      */

--- a/starters/gatsby-starter-wordpress-blog/package.json
+++ b/starters/gatsby-starter-wordpress-blog/package.json
@@ -15,6 +15,7 @@
     "gatsby-plugin-offline": "^3.3.3",
     "gatsby-plugin-react-helmet": "^3.3.14",
     "gatsby-plugin-sharp": "^2.7.1",
+    "gatsby-source-filesystem": "^2.10.0",
     "gatsby-source-wordpress-experimental": "^7.0.0",
     "gatsby-transformer-sharp": "^2.5.21",
     "html-react-parser": "^0.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,6 +3786,14 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/readable-stream@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.9.tgz#40a8349e6ace3afd2dd1b6d8e9b02945de4566a9"
+  integrity sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==
+  dependencies:
+    "@types/node" "*"
+    safe-buffer "*"
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -9332,6 +9340,16 @@ file-type@^15.0.1:
     token-types "^2.0.0"
     typedarray-to-buffer "^3.1.5"
 
+file-type@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.2.0.tgz#d4f1da71ddda758db7f15f93adfaed09ce9e2715"
+  integrity sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.0.3"
+    token-types "^2.0.0"
+    typedarray-to-buffer "^3.1.5"
+
 file-type@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
@@ -9830,6 +9848,19 @@ gatsby-core-utils@^1.6.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.9.0.tgz#ff349cc2013fd06a85099b3aee061b01f64ceabb"
+  integrity sha512-AWq9E+rBY+fWJrhdOx0rn/LlZ0eCjpqLYlDcUmLZ5NjwLARgkEXNf4JsvDETLtThcNlSOibEMQex8arsYatmkA==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.7.0.tgz#7b98c51f4fc2b66064ce16aa107b8e34dc664fa0"
@@ -10076,6 +10107,25 @@ gatsby-recipes@^0.5.0:
     ws "^7.3.0"
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
+
+gatsby-source-filesystem@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.10.0.tgz#9ee2f770d3ae15062a111bb1faea76b7d6e2b059"
+  integrity sha512-kf1D25wBe+mXa+c4C0HgI+5bwgEoTUQupP1q7nk4Q1+RC2mHlWSm3X+lNPWVfxg8MKNWrLmrX1GrXorW8cEtEQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    better-queue "^3.8.10"
+    chokidar "^3.4.3"
+    file-type "^16.0.0"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.9.0"
+    got "^9.6.0"
+    md5-file "^5.0.0"
+    mime "^2.4.6"
+    pretty-bytes "^5.4.1"
+    progress "^2.0.3"
+    valid-url "^1.0.9"
+    xstate "^4.14.0"
 
 gatsby-source-filesystem@^2.3.37:
   version "2.3.37"
@@ -16870,6 +16920,14 @@ readable-web-to-node-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz#751e632f466552ac0d5c440cc01470352f93c4b7"
   integrity sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==
 
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz#3f619b1bc5dd73a4cfe5c5f9b4f6faba55dff845"
+  integrity sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==
+  dependencies:
+    "@types/readable-stream" "^2.3.9"
+    readable-stream "^3.6.0"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -17541,15 +17599,15 @@ rxjs@^6.6.0, rxjs@^6.6.2:
   dependencies:
     tslib "^1.9.0"
 
+safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -20581,6 +20639,11 @@ xstate@^4.11.0, xstate@^4.13.0, xstate@^4.9.1:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.13.0.tgz#0be22ceb8bae2bc6a025fab330fe44204d76771c"
   integrity sha512-UnUJJzP2KTPqnmxIoD/ymXtpy/hehZnUlO6EXqWC/72XkPb15p9Oz/X4WhS3QE+by7NP+6b5bCi/GTGFzm5D+A==
+
+xstate@^4.14.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.0.tgz#e434d0558c0f9a7e9212802834992a6c2f47bca6"
+  integrity sha512-2k/49QYLdzG6Ye1JQWYFuPdU6dnRqHXcuFLxuORiuel04GjApSPct7wp2SOz9RAlNME5EkzclRKw1fHm5yejuA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This addition to the starter + docs allows querying the public URL of a file directly.

```graphql
{
  allWpPost {
    nodes {
      featuredImage {
        node {
          localFile {
            publicURL
          }
        }
      }
    }
  }
}
```