### PR TITLE
Docs: add transforming data tutorial

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -7,6 +7,7 @@
 5. @todo Working with Menus
 6. @todo Working with large WordPress sites
 7. [Using Self-Signed Certificates](./using-self-signed-certificates.md)
+8. [Tranforming Node Data](./transforming-data.md)
 
 # Up Next :point_right:
 

--- a/docs/tutorials/transforming-data.md
+++ b/docs/tutorials/transforming-data.md
@@ -8,14 +8,10 @@ A good example on how to use this API is by referencing internal uses of it. In 
 
 ```js
 const defaultPluginOptions = {
-    // ...
+  // ...
   type: {
     MediaItem: {
-      beforeChangeNode: async ({
-        remoteNode,
-        actionType,
-        typeSettings,
-      }) => {
+      beforeChangeNode: async ({ remoteNode, actionType, typeSettings }) => {
         // we fetch lazy nodes files in resolvers, no need to fetch them here.
         if (typeSettings.lazyNodes) {
           return {
@@ -64,25 +60,25 @@ A good example of why you might want to perform some side effects before a node 
 export const menuBeforeChangeNode = async (api) => {
   if (api.remoteNode && api.actionType === `DELETE`) {
     const {
-        pluginOptions,
-        helpers: { getNodesByType, actions },
+      pluginOptions,
+      helpers: { getNodesByType, actions },
     } = api.helpers
 
     // get all existing MenuItem nodes
     const allMenuItems = getNodesByType(
-        `${pluginOptions.schema.typePrefix}MenuItem`
+      `${pluginOptions.schema.typePrefix}MenuItem`
     )
 
     // find the nodes that are children of the current menu
     const allMenuItemsNodesWithThisMenuIdAsAParent = allMenuItems.filter(
-        (menuItemNode) => menuItemNode.menu.node.id === api.remoteNode.id
+      (menuItemNode) => menuItemNode.menu.node.id === api.remoteNode.id
     )
 
     // delete each child menu item
     allMenuItemsNodesWithThisMenuIdAsAParent?.forEach((menuItemNode) =>
-        actions.deleteNode({
-            node: menuItemNode,
-        })
+      actions.deleteNode({
+        node: menuItemNode,
+      })
     )
   }
 }
@@ -96,14 +92,14 @@ There may be cases where you want to cancel a node create/update/delete before i
 
 ```js
 const beforeChangeNodePage = ({ remoteNode, actionType }) => {
-    if (
-        [`CREATE`, `CREATE_ALL`, `UPDATE`].includes(actionType) &&
-        remoteNode.language !== process.env.BUILD_LANGUAGE
-    ) {
-        return {
-            cancelUpdate: true
-        }
+  if (
+    [`CREATE`, `CREATE_ALL`, `UPDATE`].includes(actionType) &&
+    remoteNode.language !== process.env.BUILD_LANGUAGE
+  ) {
+    return {
+      cancelUpdate: true,
     }
+  }
 }
 ```
 

--- a/docs/tutorials/transforming-data.md
+++ b/docs/tutorials/transforming-data.md
@@ -86,7 +86,7 @@ export const menuBeforeChangeNode = async (api) => {
 
 Here we're finding all child MenuItem's on the MenuItem being deleted and then deleting those items. We do this as a performance optimization. In WP if a Menu is deleted, the child MenuItem's are also deleted. Instead of sending an event for each item and needing Gatsby to fetch all of them, we know that when we receive an event to delete a Menu, we can safely delete its child MenuItem's.
 
-# Cancelling an update
+## Cancelling an update
 
 There may be cases where you want to cancel a node create/update/delete before it happens. You can do that by adding `cancelUpdate: true` to the object you return to this API. A common use-case for doing this is when you have a multi-lingual site split across multiple domains where each language has a separate Gatsby build process.
 

--- a/docs/tutorials/transforming-data.md
+++ b/docs/tutorials/transforming-data.md
@@ -1,0 +1,110 @@
+# Transforming Data
+
+There are some cases where you may want to modify data as it's fetched from WPGraphQL but before it's stored in Gatsby. This source plugin does that quite a bit itself for html transformations and image processing. Because it's such a common need for implementing advanced use cases like automatic image optimization and building transformer plugins, we have a built in API for this (`options.type.[typename].beforeChangeNode`). This API is called before any node is created, updated, or deleted.
+
+## Modifying nodes when created or updated
+
+A good example on how to use this API is by referencing internal uses of it. In `src/models/gatsby-api.ts` you will see the following code:
+
+```js
+const defaultPluginOptions = {
+    // ...
+  type: {
+    MediaItem: {
+      beforeChangeNode: async ({
+        remoteNode,
+        actionType,
+        typeSettings,
+      }) => {
+        // we fetch lazy nodes files in resolvers, no need to fetch them here.
+        if (typeSettings.lazyNodes) {
+          return {
+            remoteNode,
+          }
+        }
+
+        if (
+          actionType === `CREATE_ALL` ||
+          actionType === `CREATE` ||
+          actionType === `UPDATE`
+        ) {
+          const createdMediaItem = await createRemoteMediaItemNode({
+            mediaItemNode: remoteNode,
+            parentName: `Node action ${actionType}`,
+          })
+
+          if (createdMediaItem) {
+            remoteNode.localFile = {
+              id: createdMediaItem.id,
+            }
+
+            return {
+              remoteNode,
+            }
+          }
+        }
+
+        return {
+          remoteNode,
+        }
+      },
+    },
+  },
+}
+```
+
+As you can see, `beforeChangeNode` allows us to either leave a node as-is, modify it, or perform some related side effects before returning.
+The above code example fetches files from WPGraphQL and creates local Gatsby nodes on every `CREATE` or `UPDATE` action for the node being processed. After creating a local file node, we save the id of that node so that we can later link this node to the file node we created.
+
+## Performing side-effects before deleting a node
+
+A good example of why you might want to perform some side effects before a node is deleted can be seen in our internal usage of this API for Menu nodes:
+
+```js
+export const menuBeforeChangeNode = async (api) => {
+  if (api.remoteNode && api.actionType === `DELETE`) {
+    const {
+        pluginOptions,
+        helpers: { getNodesByType, actions },
+    } = api.helpers
+
+    // get all existing MenuItem nodes
+    const allMenuItems = getNodesByType(
+        `${pluginOptions.schema.typePrefix}MenuItem`
+    )
+
+    // find the nodes that are children of the current menu
+    const allMenuItemsNodesWithThisMenuIdAsAParent = allMenuItems.filter(
+        (menuItemNode) => menuItemNode.menu.node.id === api.remoteNode.id
+    )
+
+    // delete each child menu item
+    allMenuItemsNodesWithThisMenuIdAsAParent?.forEach((menuItemNode) =>
+        actions.deleteNode({
+            node: menuItemNode,
+        })
+    )
+  }
+}
+```
+
+Here we're finding all child MenuItem's on the MenuItem being deleted and then deleting those items. We do this as a performance optimization. In WP if a Menu is deleted, the child MenuItem's are also deleted. Instead of sending an event for each item and needing Gatsby to fetch all of them, we know that when we receive an event to delete a Menu, we can safely delete its child MenuItem's.
+
+# Cancelling an update
+
+There may be cases where you want to cancel a node create/update/delete before it happens. You can do that by adding `cancelUpdate: true` to the object you return to this API. A common use-case for doing this is when you have a multi-lingual site split across multiple domains where each language has a separate Gatsby build process.
+
+```js
+const beforeChangeNodePage = ({ remoteNode, actionType }) => {
+    if (
+        [`CREATE`, `CREATE_ALL`, `UPDATE`].includes(actionType) &&
+        remoteNode.language !== process.env.BUILD_LANGUAGE
+    ) {
+        return {
+            cancelUpdate: true
+        }
+    }
+}
+```
+
+Now each build will only receive updates for the language specified in the `BUILD_LANGUAGE` env variable and updates for nodes of other languages will be cancelled.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^6.14.0",
     "eslint-plugin-filenames": "^1.3.2",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-prettier": "^3.3.1",
     "fs-extra": "^9.1.0",
     "gatsby-plugin-utils": "^0.3.0",
     "handlebars": "^4.7.6",

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -12,9 +12,7 @@ import { NodePluginArgs } from "gatsby"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
-  void
-> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -73,9 +71,10 @@ const invokeLeftoverPreviewCallback = ({
   context?: string
   error?: Error
   getNode: NodePluginArgs["getNode"]
-}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
-  void
-> => {
+}) => async ([nodeId, callback]: [
+  string,
+  OnPageCreatedCallback
+]): Promise<void> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/yarn.lock
+++ b/yarn.lock
@@ -8650,10 +8650,10 @@ eslint-plugin-jsx-a11y@^6.3.1:
     jsx-ast-utils "^2.4.1"
     language-tags "^1.0.5"
 
-eslint-plugin-prettier@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
-  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+eslint-plugin-prettier@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
This mini tutorial explains how to transform node data on its way to Gatsby. This tutorial is intentionally brief as it's only meant for advanced developers who are building Gatsby plugins or very much know what they're getting into.