### PR TITLE
Fix: add missing "where" type option

### DIFF
--- a/docs/plugin-options.md
+++ b/docs/plugin-options.md
@@ -46,6 +46,7 @@
   - [html.createStaticFiles](#htmlcreatestaticfiles)
 - [type](#type)
   - [type.\_\_all](#type__all)
+    - [type.\_\_all.where](#type__allwhere)
     - [type.\_\_all.exclude](#type__allexclude)
     - [type.\_\_all.limit](#type__alllimit)
     - [type.\_\_all.excludeFieldNames](#type__allexcludefieldnames)
@@ -927,6 +928,24 @@ A special type setting which is applied to all types in the ingested schema.
       __all: {
         limit: 10,
       },
+    },
+  },
+}
+
+```
+
+#### type.\_\_all.where
+
+This string is passed as the WPGraphQL "where" arguments in the GraphQL queries that are made while initially sourcing all data from WPGraphQL into Gatsby during an uncached build. A common use-case for this is only fetching posts of a specific language. It's often used in conjunction with the beforeChangeNode type option as "where" only affects the initial data sync from WP to Gatsby while beforeChangeNode will also run when syncing individual updates from WP to Gatsby.
+
+**Field type**: `String`
+
+```js
+{
+  resolve: `gatsby-source-wordpress-experimental`,
+  options: {
+    schema: {
+      where: `language: ${process.env.GATSBY_ACTIVE_LANGUAGE}`,
     },
   },
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -53,6 +53,7 @@
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-proposal-private-methods": "^7.10.1",
+    "@types/hapi__joi": "^17.1.6",
     "@types/semver": "^7.3.4",
     "babel-jest": "^25.1.0",
     "babel-plugin-import-globals": "^2.0.0",

--- a/plugin/src/steps/declare-plugin-options-schema.ts
+++ b/plugin/src/steps/declare-plugin-options-schema.ts
@@ -17,6 +17,19 @@ const wrapOptions = (innerOptions) =>
 export function pluginOptionsSchema({ Joi }: { Joi: Root }): SchemaLike {
   const getTypeOptions = () =>
     Joi.object({
+      where: Joi.string()
+        .allow(null)
+        .allow(false)
+        .meta({
+          example: wrapOptions(`
+              schema: {
+                where: \`language: \${process.env.GATSBY_ACTIVE_LANGUAGE}\`
+              }
+            `),
+        })
+        .description(
+          `This string is passed as the WPGraphQL "where" arguments in the GraphQL queries that are made while initially sourcing all data from WPGraphQL into Gatsby during an uncached build. A common use-case for this is only fetching posts of a specific language. It's often used in conjunction with the beforeChangeNode type option as "where" only affects the initial data sync from WP to Gatsby while beforeChangeNode will also run when syncing individual updates from WP to Gatsby.`
+        ),
       exclude: Joi.boolean()
         .allow(null)
         .description(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3599,6 +3599,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hapi__joi@^17.1.6":
+  version "17.1.6"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-17.1.6.tgz#b84663676aa9753c17183718338dd40ddcbd3754"
+  integrity sha512-y3A1MzNC0FmzD5+ys59RziE1WqKrL13nxtJgrSzjoO7boue5B7zZD2nZLPwrSuUviFjpKFQtgHYSvhDGfIE4jA==
+
 "@types/history@*":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"


### PR DESCRIPTION
options.type.[typename].where was missing. Not anymore :D