### PR TITLE
Docs: Add a "starting with a starter" tutorial

### DIFF
--- a/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md
+++ b/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md
@@ -1,10 +1,10 @@
-## Creating a new site from scratch
+# Creating a new site from scratch
 
-### What this tutorial covers:
+## What this tutorial covers:
 
 In this tutorial, you will install the `gatsby-source-wordpress-experimental` plugin in order to pull blog and image data from a WordPress install into your Gatsby site and render that data. This [Gatsby + WordPress starter](https://github.com/henrikwirth/gatsby-starter-wordpress-twenty-twenty) shows you the source code for an example site similar to what you’re going to be building in this tutorial.
 
-### Creating a site with the `gatsby-source-wordpress-experimental` plugin
+## Creating a site with the `gatsby-source-wordpress-experimental` plugin
 
 Create a new Gatsby project and change directories into the new project you just created:
 
@@ -75,7 +75,7 @@ module.exports = {
 }
 ```
 
-### Creating GraphQL queries that pull data from WordPress
+## Creating GraphQL queries that pull data from WordPress
 
 Now you are ready to create a GraphQL query to pull in some data from the WordPress site. You will create a query that pulls in the title of the blog posts, date they were posted, and blogpost content.
 
@@ -167,7 +167,7 @@ export const pageQuery = graphql`
 
 Save these changes and look at `http://localhost:8000` to see your new homepage with a list of sorted blog posts!
 
-## Create pages for each blog post and link to them
+## Creating pages for each blog post and linking to them
 
 An index page with a post title and excerpt is great, but you should also build pages out for each of the blog posts, and link to them from your `index.js` file.
 

--- a/docs/tutorials/creating-a-new-site-from-a-starter.md
+++ b/docs/tutorials/creating-a-new-site-from-a-starter.md
@@ -1,0 +1,129 @@
+# Creating a new site from a starter
+
+This is the recommended way to build new sites so that you start with good best practises and don't need to re-implement everything yourself.
+
+## Setting up WordPress
+
+If you don't have a WP site yet, we recommend creating a local WP instance using [Local by Flywheel](https://localwp.com/) but as long as you have a WP instance hosted somewhere you're good to get started.
+
+Log into your WP instance and navigate to `/wp-admin/plugin-install.php`. Once you're there, search for and install these two plugins:
+
+- [WPGraphQL](https://wordpress.org/plugins/wp-graphql/)
+- [WPGatsby](https://wordpress.org/plugins/wp-gatsby/)
+
+We need WPGraphQL so that we have an efficient and flexible way for `gatsby-source-wordpress` to pull data into Gatsby.
+WPGatsby is also required as it sets up a WP admin event log that Gatsby will use to pull content changes into Gatsby after our initial build. It also offers some additional features like [Gatsby Preview](../features/preview.md) and [webhooks](./configuring-wp-gatsby.md) to kick off builds on your build service when content changes in WP.
+
+## Setting up Gatsby
+
+First you'll need to ensure you have npm, Gatsby, and Nodejs installed on your computer. Follow the [GatsbyJS guide on setting up your development environment](https://www.gatsbyjs.com/docs/tutorial/part-zero/).
+
+## Setting up `gatsby-source-wordpress-experimental`
+
+You're super close to being able to run your new Gatsby/WP site now!
+
+1. In a terminal, `cd` (navigate) to the directory you want your Gatsby site to live in.
+2. To create a new site using the official WP Gatsby starter, run `gatsby new my-wordpress-gatsby-site https://github.com/gatsbyjs/gatsby-starter-wordpress-blog`. That will fetch [this starter](https://github.com/gatsbyjs/gatsby-starter-wordpress-blog) and put it in a new directory called `my-wordpress-gatsby-site` and run `npm install`. 
+
+Now that you have a local Gatsby site installed, open it in your favourite IDE or text editor and open up the `gatsby-config.js` file.
+At the top of the `plugins` array you'll see the following code:
+
+```js
+    {
+      /**
+       * First up is the WordPress source plugin that connects Gatsby
+       * to your WordPress site.
+       *
+       * visit the plugin docs to learn more
+       * https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/README.md
+       *
+       */
+      resolve: `gatsby-source-wordpress-experimental`,
+      options: {
+        // the only required plugin option for WordPress is the GraphQL url.
+        url:
+          process.env.WPGRAPHQL_URL ||
+          `https://wpgatsbydemo.wpengine.com/graphql`,
+      },
+    },
+```
+
+As you can see, the `url` option is the only required option. You will want to replace this with the URL of the `/graphql` endpoint you added by installing WPGraphQL in your WP instance. Out of the box WPGraphQL will add the GraphQL endpoint at `http://[yoursite.com]/graphql`.
+
+```js
+    {
+      resolve: `gatsby-source-wordpress-experimental`,
+      options: {
+        url: `https://demo.wpgraphql.com/graphql`,
+      },
+    },
+```
+
+## Running the site
+
+Now that you have the source plugin configured you can check it out by `cd`ing into your site directory in a terminal and running `gatsby develop`. You should see the plugin output some lines in your terminal showing which types of data it's fetching from WPGraphQL. On the first build (`gatsby develop` or `gatsby build`) `gatsby-source-wordpress-experimental` will fetch all available public data from WPGraphQL. On subsequent builds, it will only fetch changed data to keep your builds quick.
+
+Open http://localhost:8000 in the browser to view your site.
+
+## Modifying the starter code
+
+For a guide on how different parts of the code work, check out this [gatsbyjs.com guide on using WordPress data](https://www.gatsbyjs.com/docs/how-to/sourcing-data/sourcing-from-wordpress/#using-wordpress-data).
+
+## Helpful plugin options for larger sites
+
+If you have a larger site you may find that the amount of time it takes for you to run `gatsby develop` is too long. Any time you add a new npm package, edit your `gatsby-config.js` or `gatsby-node.js` files, Gatsby will clear the cache and the source plugin will need to re-fetch all data. We can mitigate that with a couple options:
+
+### Limiting the amount of data fetched with the `options.type.[typename].limit` option
+
+```js
+    {
+      resolve: `gatsby-source-wordpress-experimental`,
+      options: {
+        url: `https://demo.wpgraphql.com/graphql`,
+        type: {
+            __all: {
+                limit: process.env.NODE_ENV === `development` ? 50 : null
+            }
+        }
+      },
+    },
+```
+
+This option will limit the total number of nodes fetched per-type. In this example we're using the special `__all` type which applies to all node types. If you wanted to change the limit based on a specific type you could do something like this:
+
+```js
+    {
+      resolve: `gatsby-source-wordpress-experimental`,
+      options: {
+        url: `https://demo.wpgraphql.com/graphql`,
+        type: {
+            Post: {
+                limit: 50
+            },
+            Page: {
+                limit: 50
+            }
+        }
+      },
+    },
+```
+
+Note that `process.env.NODE_ENV === "development" ? 50 : null`  will apply this limit only during development while `limit: 50` will apply a limit during development and in production builds.
+
+### Hard caching MediaItem local files in development using the `options.develop.hardCacheMediaFiles` option
+
+When the Gatsby cache is cleared all image files that the source plugin fetched from WordPress will be deleted. That means they will then need to be immediately re-downloaded when you run `gatsby develop` again. We can eliminate this problem in development with the `hardCacheMediaFiles` option:
+
+```js
+    {
+      resolve: `gatsby-source-wordpress-experimental`,
+      options: {
+        url: `https://demo.wpgraphql.com/graphql`,
+        develop: {
+            hardCacheMediaFiles: true,
+        }
+      },
+    },
+```
+
+Now you'll only ever need to fetch media item files 1 time on your local machine.

--- a/docs/tutorials/creating-a-new-site-from-a-starter.md
+++ b/docs/tutorials/creating-a-new-site-from-a-starter.md
@@ -23,7 +23,7 @@ First you'll need to ensure you have npm, Gatsby, and Nodejs installed on your c
 You're super close to being able to run your new Gatsby/WP site now!
 
 1. In a terminal, `cd` (navigate) to the directory you want your Gatsby site to live in.
-2. To create a new site using the official WP Gatsby starter, run `gatsby new my-wordpress-gatsby-site https://github.com/gatsbyjs/gatsby-starter-wordpress-blog`. That will fetch [this starter](https://github.com/gatsbyjs/gatsby-starter-wordpress-blog) and put it in a new directory called `my-wordpress-gatsby-site` and run `npm install`. 
+2. To create a new site using the official WP Gatsby starter, run `gatsby new my-wordpress-gatsby-site https://github.com/gatsbyjs/gatsby-starter-wordpress-blog`. That will fetch [this starter](https://github.com/gatsbyjs/gatsby-starter-wordpress-blog) and put it in a new directory called `my-wordpress-gatsby-site` and run `npm install`.
 
 Now that you have a local Gatsby site installed, open it in your favourite IDE or text editor and open up the `gatsby-config.js` file.
 At the top of the `plugins` array you'll see the following code:
@@ -108,7 +108,7 @@ This option will limit the total number of nodes fetched per-type. In this examp
     },
 ```
 
-Note that `process.env.NODE_ENV === "development" ? 50 : null`  will apply this limit only during development while `limit: 50` will apply a limit during development and in production builds.
+Note that `process.env.NODE_ENV === "development" ? 50 : null` will apply this limit only during development while `limit: 50` will apply a limit during development and in production builds.
 
 ### Hard caching MediaItem local files in development using the `options.develop.hardCacheMediaFiles` option
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,14 +1,13 @@
 # Tutorials
 
-1. @todo Building a new site using a starter
+1. [Creating a new site using a starter (recommended)](./creating-a-new-site-from-a-starter.md)
 2. [Creating a new site from scratch](./building-a-new-site-wordpress-and-gatsby.md)
 3. [Configuring WPGatsby for Fast/Incremental Builds, and Preview](./configuring-wp-gatsby.md)
 4. [Querying Data](./querying-data.md)
 5. [Working with Nav Menus](./using-wordpress-menus.md)
 6. [Using Advanced Custom Fields](./using-advanced-custom-fields.md)
-7. @todo Working with large WordPress sites
-8. [Using Self-Signed Certificates](./using-self-signed-certificates.md)
-9. [Tranforming Node Data](./transforming-data.md)
+7. [Using Self-Signed Certificates](./using-self-signed-certificates.md)
+8. [Tranforming Node Data](./transforming-data.md)
 
 # Up Next :point_right:
 

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -12,7 +12,9 @@ import { NodePluginArgs } from "gatsby"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
+  void
+> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -71,10 +73,9 @@ const invokeLeftoverPreviewCallback = ({
   context?: string
   error?: Error
   getNode: NodePluginArgs["getNode"]
-}) => async ([nodeId, callback]: [
-  string,
-  OnPageCreatedCallback
-]): Promise<void> => {
+}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
+  void
+> => {
   const passedNode = getNode(nodeId)
 
   await callback({

--- a/plugin/src/steps/preview/cleanup.ts
+++ b/plugin/src/steps/preview/cleanup.ts
@@ -12,9 +12,7 @@ import { NodePluginArgs } from "gatsby"
  * preview callbacks haven't been invoked, and invoke them with a "NO_PAGE_CREATED_FOR_PREVIEWED_NODE" status, which sends that status to WP
  * After invoking all these leftovers, we clear them out from the store so they aren't called again later.
  */
-export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<
-  void
-> => {
+export const onPreExtractQueriesInvokeLeftoverPreviewCallbacks = async (): Promise<void> => {
   if (!inPreviewMode()) {
     return invokeAndCleanupLeftoverPreviewCallbacks({
       status: `GATSBY_PREVIEW_PROCESS_ERROR`,
@@ -73,9 +71,10 @@ const invokeLeftoverPreviewCallback = ({
   context?: string
   error?: Error
   getNode: NodePluginArgs["getNode"]
-}) => async ([nodeId, callback]: [string, OnPageCreatedCallback]): Promise<
-  void
-> => {
+}) => async ([nodeId, callback]: [
+  string,
+  OnPageCreatedCallback
+]): Promise<void> => {
   const passedNode = getNode(nodeId)
 
   await callback({


### PR DESCRIPTION
This PR adds a new tutorial explaining how to get started with the official blog starter.