### PR TITLE
fix: bump axios version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 7.0.4
+
+Upgraded `axios` to v0.21.0 because older versions were susceptible to SSRF attacks. https://www.npmjs.com/advisories/1594
+
 ## 7.0.3
 
 ### Bug Fixes

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -14,7 +14,7 @@
     "@types/ink": "^2.0.3",
     "async-retry": "^1.3.1",
     "atob": "^2.1.2",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "axios-rate-limit": "^1.3.0",
     "better-queue": "^3.8.10",
     "btoa": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5337,6 +5337,13 @@ axios@^0.20.0:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"


### PR DESCRIPTION
This vuln doesn't effect users of gatsby-source-wordpress-experimental since we're not using the proxy feature the vuln was related to but we need to upgrade since `npm audit` fails on this meaning we can't merge our starter into the monorepo
https://www.npmjs.com/advisories/1594